### PR TITLE
Redis install dir

### DIFF
--- a/ansible/roles/vendor/gsa.datagov-deploy-redis/meta/.galaxy_install_info
+++ b/ansible/roles/vendor/gsa.datagov-deploy-redis/meta/.galaxy_install_info
@@ -1,1 +1,1 @@
-{install_date: 'Mon Sep 10 17:20:34 2018', version: install-dir}
+{install_date: 'Mon Sep 10 17:56:26 2018', version: ''}

--- a/ansible/roles/vendor/gsa.datagov-deploy-redis/meta/.galaxy_install_info
+++ b/ansible/roles/vendor/gsa.datagov-deploy-redis/meta/.galaxy_install_info
@@ -1,1 +1,1 @@
-{install_date: 'Thu Sep  6 01:16:16 2018', version: ''}
+{install_date: 'Mon Sep 10 17:20:34 2018', version: install-dir}

--- a/ansible/roles/vendor/gsa.datagov-deploy-redis/meta/main.yml
+++ b/ansible/roles/vendor/gsa.datagov-deploy-redis/meta/main.yml
@@ -7,3 +7,4 @@ dependencies:
     redis_pidfile: /var/run/redis/redis-server.pid
     redis_logfile: /var/log/redis/redis-server.log
     redis_version: 4.0.11
+    redis_install_dir: /usr/local

--- a/ansible/roles/vendor/requirements.yml
+++ b/ansible/roles/vendor/requirements.yml
@@ -31,5 +31,4 @@
   name: gsa.rvm1-ruby
 
 - src: https://github.com/GSA/datagov-deploy-redis
-  version: install-dir
   name: gsa.datagov-deploy-redis

--- a/ansible/roles/vendor/requirements.yml
+++ b/ansible/roles/vendor/requirements.yml
@@ -31,4 +31,5 @@
   name: gsa.rvm1-ruby
 
 - src: https://github.com/GSA/datagov-deploy-redis
+  version: install-dir
   name: gsa.datagov-deploy-redis


### PR DESCRIPTION
Updates redis install directory to `/usr/local` to avoid permissions issue in `/opt` with the hardening script.