### PR TITLE
[newrelic] install python newrelic to virtualenv

### DIFF
--- a/ansible/roles/monitoring/newrelic/python-agent-ansible/tasks/main.yml
+++ b/ansible/roles/monitoring/newrelic/python-agent-ansible/tasks/main.yml
@@ -5,17 +5,9 @@
     current_env: "{{ inventory_dir | basename }}"
 
 - name: Install the New Relic Python agent
-  pip: name=newrelic
+  pip: name=newrelic virtualenv=/usr/lib/ckan umask=022
   when: (current_env == 'staging') or (current_env == 'production')
-
-- name: Fix newrelic package permissions
-  file:
-    path: /usr/local/lib/python2.7/dist-packages
-    state: directory
-    recurse: yes
-    group: www-data
-    mode: 0755
-  when: (current_env == 'staging') or (current_env == 'production')
+  notify: restart apache
 
 - name: Generate apache.wsgi
   template:
@@ -23,6 +15,7 @@
     dest: "{{ ckan_config_path }}/apache.wsgi"
     mode: '0755'
   when: (current_env == 'staging') or (current_env == 'production')
+  notify: restart apache
 
 - name: Create Newrelic config folder
   file:


### PR DESCRIPTION
This is a bit of a hack, since I'm hard-coding the virtualenv path in the role. Ultimately I think this playbook will go away, so I'm okay with this shortcut for now.

Newrelic should be integrated into catalog-app or the inventory role, since it requires installing python dependencies into the virtualenv. The configuration can be turned on/off through the config or environment variable based on the environment but it really should be considered an application dependency, not an os-level concern (and not a datagov-deploy concern)