### PR TITLE
[jumpbox] configure jumpbox with postfix

### DIFF
--- a/ansible/jumpbox.yml
+++ b/ansible/jumpbox.yml
@@ -6,4 +6,5 @@
   become_method: sudo
 
   roles:
+    - { role: software/common/ansible-postfix, tags: ['postfix'] }
     - { role: software/jumpbox }


### PR DESCRIPTION
All hosts have postfix installed, but for jumpbox this lets us run CI/CD tasks
from the jumpbox and report out.