### PR TITLE
Run plays on hosts in serial

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -245,7 +245,6 @@ nocows = 1
 # You can disable this feature by setting retry_files_enabled to False
 # and you can change the location of the files by setting retry_files_save_path
 
-retry_files_enabled = False
 #retry_files_save_path = ~/.ansible-retry
 
 # squash actions

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -100,7 +100,7 @@ timeout = 10
 
 # default user to use for playbooks if user is not specified
 # (/usr/bin/ansible will use current user as default)
-#remote_user = root
+remote_user = ubuntu
 
 # logging is off by default unless this path is defined
 # if so defined, consider logrotate
@@ -319,10 +319,8 @@ retry_files_enabled = False
 #any_errors_fatal = False
 
 [privilege_escalation]
-#become=True
-#become_method=sudo
-#become_user=root
-#become_ask_pass=False
+become=True
+become_method=sudo
 
 [paramiko_connection]
 

--- a/ansible/catalog.yml
+++ b/ansible/catalog.yml
@@ -1,9 +1,7 @@
 ---
 - name: Install CKAN Stack
-  hosts: all
-  become: yes
-  become_method: sudo
-  remote_user: ubuntu
+  hosts: catalog-web:catalog-harvester
+  serial: 1
   vars:
       app_type: catalog
 

--- a/ansible/ckan-native-login.yml
+++ b/ansible/ckan-native-login.yml
@@ -1,7 +1,7 @@
 ---
 - name: Configure user/password authentication for CKAN
   hosts: catalog-web
-  become: true
+  serial: 2
   vars:
     app_type: catalog
   roles:

--- a/ansible/crm-web.yml
+++ b/ansible/crm-web.yml
@@ -9,10 +9,7 @@
 
 - name: Provisioning Web AMI
   hosts: crm-web
-  remote_user: ubuntu
-  become: yes
-  become_method: sudo
-
+  serial: 1
   roles:
   - software/common/die-no-tags
   - { role: software/common/misc, tags: [provision, misc] }
@@ -35,8 +32,7 @@
 
 - name: Deploying crm
   hosts: crm-web
-  remote_user: ubuntu
-
+  serial: 1
   roles:
   - { role: software/crm/crm-deploy, tags: [provision, deploy] }
   - { role: software/common/datagov-deploy-rollback, tags: [deploy-rollback] }
@@ -44,17 +40,13 @@
 
 - name: Cleanup
   hosts: crm-web
-  remote_user: ubuntu
-  become: yes
-  become_method: sudo
-
+  serial: 1
   roles:
   - { role: software/common/php-fixes, tags: [php, provision, deploy] }
   - { role: software/crm/crm-sudo-3-cleanup, tags: [provision, deploy, deploy-rollback] }
 
 - name: CRM Migration
   hosts: crm-web
-  remote_user: ubuntu
-
+  serial: 1
   roles:
   - { role: software/crm/crm-migrations, tags: [provision, deploy, migrate] }

--- a/ansible/dashboard-web.yml
+++ b/ansible/dashboard-web.yml
@@ -10,10 +10,7 @@
 
 - name: Provisioning Web AMI
   hosts: dashboard-web
-  remote_user: ubuntu
-  become: yes
-  become_method: sudo
-
+  serial: 1
   roles:
   - software/common/die-no-tags
   - { role: software/common/misc, tags: [provision, misc] }
@@ -36,8 +33,7 @@
 
 - name: Deploying Dashboard
   hosts: dashboard-web
-  remote_user: ubuntu
-
+  serial: 1
   roles:
   - { role: software/dashboard/dashboard-deploy, tags: [deploy, provision] }
   - { role: software/common/datagov-deploy-rollback, tags: [deploy-rollback] }
@@ -45,10 +41,7 @@
 
 - name: Cleanup
   hosts: dashboard-web
-  remote_user: ubuntu
-  become: yes
-  become_method: sudo
-
+  serial: 1
   roles:
   - { role: software/common/php-fixes, tags: [php, provision, deploy] }
   - { role: software/dashboard/dashboard-sudo-3-cleanup, tags: [provision, deploy, deploy-rollback] }
@@ -57,7 +50,6 @@
 
 - name: Dashboard DB Migration
   hosts: dashboard-web
-  remote_user: ubuntu
-
+  serial: 1
   roles:
   - { role: software/dashboard/dashboard-db-migrations, tags: [provision, deploy, migrate] }

--- a/ansible/datagov-web.yml
+++ b/ansible/datagov-web.yml
@@ -9,10 +9,7 @@
 
 - name: Provisioning WordPress Web AMI
   hosts:  "{{ datagov_web_hosts | default('wordpress-web') }}"
-  remote_user: ubuntu
-  become: yes
-  become_method: sudo
-
+  serial: 1
   roles:
   - software/common/die-no-tags
   - { role: software/common/misc, tags: [provision, misc] }
@@ -35,8 +32,7 @@
 
 - name: Deploying Data.gov
   hosts: wordpress-web
-  remote_user: ubuntu
-
+  serial: 1
   roles:
   - { role: software/wordpress/datagov-deploy, tags: [deploy, provision] }
   - { role: software/common/datagov-deploy-rollback, tags: [deploy-rollback] }
@@ -44,10 +40,7 @@
 
 - name: Cleanup
   hosts: wordpress-web
-  remote_user: ubuntu
-  become: yes
-  become_method: sudo
-
+  serial: 1
   roles:
   - { role: software/common/php-fixes, tags: [php, provision, deploy] }
   - { role: software/wordpress/datagov-sudo-3-cleanup, tags: [provision, deploy, deploy-rollback, cleanup] }

--- a/ansible/efk-nginx.yml
+++ b/ansible/efk-nginx.yml
@@ -1,10 +1,7 @@
 ---
 - name: Install EFK nginx proxy
   hosts: efk_nginx
-  become: yes
-  become_method: sudo
-  remote_user: ubuntu
-
+  serial: 1
   roles:
   - role: geerlingguy.nginx
   - role: monitoring/efk-nginx

--- a/ansible/efk-stack.yml
+++ b/ansible/efk-stack.yml
@@ -2,9 +2,7 @@
 
 - name: Install ElasticSearch
   hosts: elasticsearch
-  become: yes
-  become_method: sudo
-  remote_user: ubuntu
+  serial: 1
   roles:
   - ANXS.apt
   - geerlingguy.java
@@ -12,26 +10,20 @@
 
 - name: Install Kibana
   hosts: kibana
-  become: yes
-  become_method: sudo
-  remote_user: ubuntu
+  serial: 1
   roles:
   - geerlingguy.kibana
 
 - name: Install EFK nginx proxy
   hosts: efk_nginx
-  become: yes
-  become_method: sudo
-  remote_user: ubuntu
+  serial: 1
   roles:
   - role: geerlingguy.nginx
   - role: monitoring/efk-nginx
 
 - name: Install Elastalert
   hosts: elasticsearch
-  become: yes
-  become_method: sudo
-  remote_user: ubuntu
+  serial: 1
   roles:
     - role: ANXS.build-essential
     - role: gsa.elastalert

--- a/ansible/elastalert.yml
+++ b/ansible/elastalert.yml
@@ -1,10 +1,7 @@
 ---
 - name: Install Elastalert
   hosts: elasticsearch
-  become: yes
-  become_method: sudo
-  remote_user: ubuntu
-
+  serial: 1
   roles:
     - { role: ANXS.build-essential }
     - { role: gsa.elastalert }

--- a/ansible/elasticsearch.yml
+++ b/ansible/elasticsearch.yml
@@ -1,9 +1,7 @@
 ---
 - name: Install ElasticSearch
   hosts: elasticsearch
-  become: yes
-  become_method: sudo
-  remote_user: ubuntu
+  serial: 1
   tasks:
     - name: installing repo for Java 8 in Ubuntu
       apt_repository: repo='ppa:openjdk-r/ppa'
@@ -11,9 +9,7 @@
 
 - name: Install ElasticSearch
   hosts: elasticsearch
-  become: yes
-  become_method: sudo
-  remote_user: ubuntu
+  serial: 1
   roles:
     - geerlingguy.java
     - { role: ansible.elasticsearch,

--- a/ansible/fluentd.yml
+++ b/ansible/fluentd.yml
@@ -1,8 +1,5 @@
 ---
 - hosts: all
-  become: yes
-  become_method: sudo
-  remote_user: ubuntu
   roles:
     - monitoring/fluentd/kernel
     - monitoring/fluentd/limits

--- a/ansible/hardening.yml
+++ b/ansible/hardening.yml
@@ -1,8 +1,4 @@
 ---
 - hosts: all
-  remote_user: ubuntu
-  become: yes
-  become_method: sudo
   roles:
     - gsa.ansible-os-ubuntu-14
-

--- a/ansible/hostname.yml
+++ b/ansible/hostname.yml
@@ -1,7 +1,4 @@
 ---
 - hosts: all
-  become: yes
-  become_method: sudo
-  remote_user: ubuntu
   roles:
     - software/common/hostname

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -1,9 +1,7 @@
 ---
 - name: Install CKAN Stack
   hosts: all
-  remote_user: ubuntu
-  become: yes
-  become_method: sudo
+  serial: 1
   vars:
     app_type: inventory
 

--- a/ansible/jekyll.yml
+++ b/ansible/jekyll.yml
@@ -1,10 +1,7 @@
 ---
 - name: Install Jekyll Apps
   hosts: jekyll-web
-  remote_user: ubuntu
-  become: yes
-  become_method: sudo
-
+  serial: 1
   vars:
     ruby_version: "2.3.0"
     gemset: "jekyll"

--- a/ansible/jumpbox.yml
+++ b/ansible/jumpbox.yml
@@ -1,9 +1,5 @@
 ---
 - name: Provision Jumpbox
   hosts: jumpbox
-  remote_user: ubuntu
-  become: yes
-  become_method: sudo
-
   roles:
     - { role: software/jumpbox }

--- a/ansible/logrotate.yml
+++ b/ansible/logrotate.yml
@@ -1,8 +1,5 @@
 ---
 - hosts: all
-  become: yes
-  become_method: sudo
-  remote_user: ubuntu
   roles:
     - role: nickhammond.logrotate
       logrotate_scripts:

--- a/ansible/nessus.yml
+++ b/ansible/nessus.yml
@@ -1,9 +1,5 @@
 ---
 - name: Install Nessus Agent
   hosts: all
-  become: yes
-  become_method: sudo
-  remote_user: ubuntu
-
   roles:
     - {role: security/nessus-agent}

--- a/ansible/newrelic-infrastructure.yml
+++ b/ansible/newrelic-infrastructure.yml
@@ -1,7 +1,4 @@
 ---
 - hosts: all
-  become: yes
-  become_method: sudo
-  remote_user: ubuntu
   roles:
     - monitoring/newrelic/infrastructure-agent-ansible

--- a/ansible/newrelic-java.yml
+++ b/ansible/newrelic-java.yml
@@ -1,8 +1,5 @@
 ---
 - hosts: all
-  become: yes
-  become_method: sudo
-  remote_user: ubuntu
   roles:
     - monitoring/newrelic/java-agent-ansible
   vars:

--- a/ansible/newrelic-php.yml
+++ b/ansible/newrelic-php.yml
@@ -1,8 +1,5 @@
 ---
 - hosts: all
-  become: yes
-  become_method: sudo
-  remote_user: ubuntu
   roles:
     - franklinkim.php5-newrelic
   vars:

--- a/ansible/newrelic-python.yml
+++ b/ansible/newrelic-python.yml
@@ -1,7 +1,4 @@
 ---
 - hosts: all
-  become: yes
-  become_method: sudo
-  remote_user: ubuntu
   roles:
     - monitoring/newrelic/python-agent-ansible

--- a/ansible/postfix.yml
+++ b/ansible/postfix.yml
@@ -2,9 +2,5 @@
 
 - name: Install postfix
   hosts: all
-  become: yes
-  become_method: sudo
-  remote_user: ubuntu
-
   roles:
     - { role: software/common/ansible-postfix }

--- a/ansible/remove_old_redis.yml
+++ b/ansible/remove_old_redis.yml
@@ -1,7 +1,5 @@
 ---
 - hosts: all
-  remote_user: ubuntu
-  become: true
   tasks:
   - name: Remove OS redis packages
     package:

--- a/ansible/secops.yml
+++ b/ansible/secops.yml
@@ -1,9 +1,5 @@
 ---
 - name: Add SecOps user
   hosts: all
-  remote_user: ubuntu
-  become: yes
-  become_method: sudo
-
   roles:
     - { role: software/common/secops-ssh }

--- a/ansible/solr.yml
+++ b/ansible/solr.yml
@@ -2,9 +2,5 @@
 
 - name: Install Solr
   hosts: all
-  remote_user: ubuntu
-  become: yes
-  become_method: sudo
-
   roles:
   - role: software/ckan/solr

--- a/ansible/trendmicro.yml
+++ b/ansible/trendmicro.yml
@@ -1,9 +1,5 @@
 ---
 - name: Install TrendMicro
   hosts: all
-  remote_user: ubuntu
-  become: yes
-  become_method: sudo
-
   roles:
     - { role: software/common/trendmicro }

--- a/ansible/web-proxy.yml
+++ b/ansible/web-proxy.yml
@@ -2,10 +2,6 @@
 
 - name: Install Nginx and configure it as a webproxy
   hosts: all
-  remote_user: ubuntu
-  become: yes
-  become_method: sudo
-
   roles:
   - role: software/catalog/nginx
     nginx_http_params:


### PR DESCRIPTION
When running playbooks on instances, we only want to affect a few at a time to avoid downtime. We have so few hosts, that running them one at a time is the only reasonable option.

I didn't go through this with a fine-tooth comb, so I'm sure there are places we can optimize. I just wanted to start at the most conservative option. We can also set serial as a variable `serial: "{{ datagov_serial }}"` so there are different settings per environment. e.g. in staging we don't really need a serial option.

This also enabled ansible retry files so that it's easier to continue where you left off if a playbook fails.