### PR TITLE
[ckan] remove Directory directive for apache

### DIFF
--- a/ansible/roles/software/catalog/ckan-app/templates/etc/apache2/sites-enabled/ckan.default.conf.j2
+++ b/ansible/roles/software/catalog/ckan-app/templates/etc/apache2/sites-enabled/ckan.default.conf.j2
@@ -24,12 +24,6 @@
 
     WSGIProcessGroup ckan
 
-    <Directory /etc/ckan>
-      Options All
-      AllowOverride All
-      Require all granted
-    </Directory>
-
     ErrorLog /var/log/apache2/ckan.error.log
 
     LogFormat "\"%{True-Client-IP}i\" %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" trueip

--- a/ansible/roles/software/catalog/ckan-app/templates/etc/apache2/sites-enabled/ckan.readonly.conf.j2
+++ b/ansible/roles/software/catalog/ckan-app/templates/etc/apache2/sites-enabled/ckan.readonly.conf.j2
@@ -24,12 +24,6 @@
 
     WSGIProcessGroup ckan
 
-    <Directory /etc/ckan>
-      Options All
-      AllowOverride All
-      Require all granted
-    </Directory>
-
     ErrorLog /var/log/apache2/ckan.error.log
 
     LogFormat "\"%{True-Client-IP}i\" %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" trueip

--- a/ansible/roles/software/catalog/ckan-app/templates/etc/apache2/sites-enabled/ckan.writable.conf.j2
+++ b/ansible/roles/software/catalog/ckan-app/templates/etc/apache2/sites-enabled/ckan.writable.conf.j2
@@ -24,12 +24,6 @@
 
     WSGIProcessGroup ckan
 
-    <Directory /etc/ckan>
-      Options All
-      AllowOverride All
-      Require all granted
-    </Directory>
-
     ErrorLog /var/log/apache2/ckan.error.log
 
     LogFormat "\"%{True-Client-IP}i\" %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" trueip

--- a/ansible/roles/software/ckan/native-login/files/etc/apache2/sites-enabled/ckan.conf
+++ b/ansible/roles/software/ckan/native-login/files/etc/apache2/sites-enabled/ckan.conf
@@ -24,12 +24,6 @@
 
     WSGIProcessGroup ckan
 
-    <Directory /etc/ckan>
-      Options All
-      AllowOverride All
-      Require all granted
-    </Directory>
-
     ErrorLog /var/log/apache2/ckan.error.log
 
     LogFormat "\"%{True-Client-IP}i\" %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" trueip

--- a/ansible/roles/software/inventory/ckan-app/files/etc/apache2/sites-enabled/ckan.conf
+++ b/ansible/roles/software/inventory/ckan-app/files/etc/apache2/sites-enabled/ckan.conf
@@ -38,12 +38,6 @@ WSGISocketPrefix /var/run/wsgi
     CustomLog /var/log/apache2/ckan.custom.log combined env=!akamai
     CustomLog /var/log/apache2/ckan.custom.log trueip env=akamai
 
-    <Directory /etc/ckan>
-      Options All
-      AllowOverride All
-      Require all granted
-    </Directory>
-
     RewriteEngine On
     RewriteCond %{HTTP_REFERER} !^https://.*\.max\.gov [NC]
     RewriteRule ^/$ /dataset [R]

--- a/ansible/roles/software/inventory/ckan-app/files/etc/apache2/sites-enabled/datapusher.conf
+++ b/ansible/roles/software/inventory/ckan-app/files/etc/apache2/sites-enabled/datapusher.conf
@@ -15,13 +15,6 @@ WSGISocketPrefix /var/run/wsgi
 
     WSGIProcessGroup datapusher
 
-    <Directory /etc/ckan>
-      Options All
-      AllowOverride All
-      Require all granted
-    </Directory>
-
     ErrorLog /var/log/apache2/datapusher.error.log
     CustomLog /var/log/apache2/datapusher.custom.log combined
-
 </VirtualHost>


### PR DESCRIPTION
This resolves nesuss 10704, Apache responding to MultiViews requests.

I'm not sure why this directive was ever included. It's not mentioned in the [CKAN installation docs](https://docs.ckan.org/en/ckan-2.3.5/maintaining/installing/deployment.html#create-the-apache-config-file).