### PR TITLE
Include SCRIPT_FILENAME for php fpm

### DIFF
--- a/ansible/roles/software/crm/crm-sudo-2-init/templates/crm.nginx.conf
+++ b/ansible/roles/software/crm/crm-sudo-2-init/templates/crm.nginx.conf
@@ -110,6 +110,7 @@ server {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         set $path_info $fastcgi_path_info;
         fastcgi_param PATH_INFO $path_info if_not_empty;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_max_temp_file_size 0;
         fastcgi_intercept_errors on;
         fastcgi_index index.php;

--- a/ansible/roles/software/dashboard/dashboard-sudo-2-init/templates/dashboard.nginx.conf
+++ b/ansible/roles/software/dashboard/dashboard-sudo-2-init/templates/dashboard.nginx.conf
@@ -109,6 +109,7 @@ server {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         set $path_info $fastcgi_path_info;
         fastcgi_param PATH_INFO $path_info if_not_empty;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_hide_header X-Powered-By;
         fastcgi_max_temp_file_size 0;
         fastcgi_intercept_errors on;

--- a/ansible/roles/software/wordpress/datagov-sudo-2-init/templates/datagov.nginx.conf
+++ b/ansible/roles/software/wordpress/datagov-sudo-2-init/templates/datagov.nginx.conf
@@ -118,6 +118,7 @@ server {
         try_files $uri =404;
 
         include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_hide_header X-Powered-By;
         fastcgi_intercept_errors on;
         fastcgi_max_temp_file_size 0;


### PR DESCRIPTION
Since we upgraded nginx, this is no longer included in fastcgi_params, so we
include it in our site config instead.

This fixes the php apps showing a blank page.