### PR TITLE
Check reboot-required before rebooting

### DIFF
--- a/ansible/actions/reboot.yml
+++ b/ansible/actions/reboot.yml
@@ -2,7 +2,15 @@
 - hosts: '!jumpbox'
   serial: 1
   tasks:
+    - name: Check if reboot is required
+      stat: path=/var/run/reboot-required
+      register: reboot_required
+
     - name: Reboot host
       command: reboot
+      when: force_reboot is defined or reboot_required.stat.exists
+      register: rebooted
+
     - name: Wait for host to come up
-      local_action: wait_for host={{ ansible_ssh_host }} state=started
+      local_action: wait_for host={{ ansible_ssh_host }} port=22 delay=60 state=started
+      when: rebooted is not skipped


### PR DESCRIPTION
This adds a check for `/var/run/reboot-required` and only reboots the host if the file exists. You can specify `ansible-playbook -e force_reboot=yes` to force a reboot.

I also tweaked the `wait_for` task. It seemed to be waiting for the full 300 second timeout even if the host came back up.

