### PR TITLE
Split tests on CI differently

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,42 +1,3 @@
-test-molecule-steps: &test-molecule-steps
-  - checkout
-  - restore_cache:
-      keys:
-        - v1-pip-{{ checksum "requirements.txt" }}
-        - v1-pip-
-  - run: |
-      virtualenv venv
-      . venv/bin/activate
-      pip install -r requirements.txt
-  - save_cache:
-      key: v1-pip-{{ checksum "requirements.txt" }}
-      paths:
-        - venv
-  - run:
-      name: Run molecule
-      command: |
-        . venv/bin/activate
-        make test-molecule-$MOLECULE_SUITE
-
-
-test-kitchen-steps: &test-kitchen-steps
-  - checkout
-  - restore_cache:
-      keys:
-        - v1-bundle-{{ checksum "Gemfile.lock" }}
-        - v1-bundle-
-  - run:
-      name: Install dependencies
-      command: bundle install --path vendor/bundle
-  - save_cache:
-      key: v1-bundle-{{ checksum "Gemfile.lock" }}
-      paths:
-        - vendor/bundle
-  - run:
-      name: Run test-kitchen
-      command: make test-kitchen-$KITCHEN_SUITE
-
-
 version: 2
 jobs:
   lint:
@@ -50,99 +11,48 @@ jobs:
       - run: echo 'password' > ~/ansible-secret.txt
       - run: make lint
 
-  test-kitchen-catalog-web:
+  test:
     machine: true
-    environment:
-      KITCHEN_SUITE: catalog-web
-    steps: *test-kitchen-steps
+    parallelism: 4
+    steps:
+      - checkout
+      # Restore cache and install python dependencies
+      - restore_cache:
+          keys:
+            - v1-pip-{{ checksum "requirements.txt" }}
+            - v1-pip-
+      - run: |
+          virtualenv venv
+          . venv/bin/activate
+          pip install -r requirements.txt
+      - save_cache:
+          key: v1-pip-{{ checksum "requirements.txt" }}
+          paths:
+            - venv
+      # Restore cache and install ruby dependencies
+      - restore_cache:
+          keys:
+            - v1-bundle-{{ checksum "Gemfile.lock" }}
+            - v1-bundle-
+      - run:
+          name: Install dependencies
+          command: bundle install --path vendor/bundle
+      - save_cache:
+          key: v1-bundle-{{ checksum "Gemfile.lock" }}
+          paths:
+            - vendor/bundle
 
-  test-kitchen-catalog-harvester:
-    machine: true
-    environment:
-      KITCHEN_SUITE: catalog-harvester
-    steps: *test-kitchen-steps
+      - run:
+          name: Run tests
+          command: |
+            . venv/bin/activate
+            TEST_TARGETS=$(make circleci-glob | circleci tests split)
+            make ${TEST_TARGETS}
 
-  test-kitchen-crm-web:
-    machine: true
-    environment:
-      KITCHEN_SUITE: crm-web
-    steps: *test-kitchen-steps
-
-  test-kitchen-dashboard-web:
-    machine: true
-    environment:
-      KITCHEN_SUITE: dashboard-web
-    steps: *test-kitchen-steps
-
-  test-kitchen-efk-nginx:
-    machine: true
-    environment:
-      KITCHEN_SUITE: efk-nginx
-    steps: *test-kitchen-steps
-
-  test-kitchen-efk-stack:
-    machine: true
-    environment:
-      KITCHEN_SUITE: efk-stack
-    steps: *test-kitchen-steps
-
-  test-kitchen-inventory-web:
-    machine: true
-    environment:
-      KITCHEN_SUITE: inventory-web
-    steps: *test-kitchen-steps
-
-  test-kitchen-jekyll:
-    machine: true
-    environment:
-      KITCHEN_SUITE: jekyll
-    steps: *test-kitchen-steps
-
-  test-kitchen-logrotate:
-    machine: true
-    environment:
-      KITCHEN_SUITE: logrotate
-    steps: *test-kitchen-steps
-
-  test-kitchen-web-proxy:
-    machine: true
-    environment:
-      KITCHEN_SUITE: web-proxy
-    steps: *test-kitchen-steps
-
-  test-molecule-software/ci:
-    machine: true
-    environment:
-      MOLECULE_SUITE: software/ci
-    steps: *test-molecule-steps
-
-  test-molecule-software/ckan/native-login:
-    machine: true
-    environment:
-      MOLECULE_SUITE: software/ckan/native-login
-    steps: *test-molecule-steps
-
-  test-kitchen-unattended-upgrades:
-    machine: true
-    environment:
-      KITCHEN_SUITE: unattended-upgrades
-    steps: *test-kitchen-steps
 
 workflows:
   version: 2
   commit:
     jobs:
       - lint
-      - test-kitchen-catalog-web
-      - test-kitchen-catalog-harvester
-      - test-kitchen-crm-web
-      - test-kitchen-dashboard-web
-      - test-kitchen-efk-nginx
-      - test-kitchen-efk-stack
-      - test-kitchen-inventory-web
-      - test-kitchen-jekyll
-      - test-kitchen-logrotate
-      - test-kitchen-web-proxy
-      - test-molecule-software/ci
-      - test-molecule-software/ckan/native-login
-      - test-kitchen-unattended-upgrades
+      - test

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,11 @@ KITCHEN_SUITE_TARGETS := $(patsubst %,test-kitchen-%,$(KITCHEN_SUITES))
 # Create test-molecule-<suite> targets
 MOLECULE_SUITE_TARGETS := $(patsubst %,test-molecule-%,$(MOLECULE_SUITES))
 
+# Used for parallelization on CircleCI. See `circleci tests glob`.
+# https://circleci.com/docs/2.0/parallelism-faster-jobs/
+circleci-glob:
+	@echo $(KITCHEN_SUITE_TARGETS) $(MOLECULE_SUITE_TARGETS) | sed -e 's/ /\n/g'
+
 update-vendor:
 	ansible-galaxy install -p ansible/roles/vendor -r ansible/roles/vendor/requirements.yml
 
@@ -47,7 +52,7 @@ $(KITCHEN_SUITE_TARGETS):
 
 $(MOLECULE_SUITE_TARGETS):
 	cd ansible/roles/$(subst test-molecule-,,$@) && \
-	molecule test
+	molecule test --all
 
 test: $(KITCHEN_SUITE_TARGETS) $(MOLECULE_SUITE_TARGETS)
 


### PR DESCRIPTION
This refactors the way we run tests in parallel on CI. Before, we created a separate CI job for each suite. This is cumbersome and error prone because when you add a new suite, you have to add it in 3 places (once to Makefile, twice to CircleCI config).

This instead uses CircleCI's split tests functionality, we list out the individual tests and CI figures out how to split them across nodes. This means we only need to our new suites to the Makefile and then we're done.