### PR TITLE
[ckan] fix solr host for native-login

### DIFF
--- a/ansible/roles/software/ckan/native-login/molecule/default/playbook.yml
+++ b/ansible/roles/software/ckan/native-login/molecule/default/playbook.yml
@@ -3,5 +3,6 @@
   hosts: all
   vars:
     CKAN_DB_SERVER: localhost
+    SOLR_SERVER: localhost
   roles:
     - role: native-login

--- a/ansible/roles/software/ckan/native-login/templates/etc/ckan/production.ini.j2
+++ b/ansible/roles/software/ckan/native-login/templates/etc/ckan/production.ini.j2
@@ -99,7 +99,7 @@ ckan.auth.roles_that_cascade_to_sub_groups = admin
 
 ckan.site_id = geo.gov
 
-solr_server = datagovsolrm1t.datagov.us
+solr_server = {{ SOLR_SERVER }}
 solr_url = http://%(solr_server)s:8080/solr/{{ app_type }}
 
 #ckan.simple_search = 1


### PR DESCRIPTION
The ckan-native-login playbook is usually run for the test environment where we don't have saml authentication, but we plan on using it in staging/production as part of the dedupe setup.