### PR TITLE
[pycsw] bump maxrecords limit

### DIFF
--- a/ansible/roles/software/catalog/pycsw-app/templates/pycsw-cfg.j2
+++ b/ansible/roles/software/catalog/pycsw-app/templates/pycsw-cfg.j2
@@ -3,7 +3,7 @@ url={{ urls_public.catalog }}/{{ csw_url_path }}
 mimetype=application/xml; charset=UTF-8
 encoding=UTF-8
 language=en-US
-maxrecords=10
+maxrecords=500
 #loglevel=DEBUG
 #logfile=/tmp/pycsw.log
 profiles=apiso


### PR DESCRIPTION
500 seems like a reasonable limit based on some very very rough testing. A 500
record response yields a 40 ~ 55M response. On a 1M connection, that's about 55
second response time. On a 4M connection (like from within AWS), more like 14 seconds.

```
$ time curl 'https://catalog.data.gov/csw-all' -d '<csw:GetRecords xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:ogc="http://www.opengis.net/ogc" service="CSW" version="2.0.2" resultType="results" startPosition="1" maxRecords="1000" outputFormat="application/xml" outputSchema="http://www.isotc211.org/2005/gmd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/cat/csw/2.0.2 http://schemas.opengis.net/csw/2.0.2/CSW-discovery.xsd">
  <csw:Query typeNames="csw:Record">
    <csw:ElementSetName>full</csw:ElementSetName>
  </csw:Query>
</csw:GetRecords>' > /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 54.6M    0 54.6M  100   557   963k      9  0:01:01  0:00:58  0:00:03 1043k

real    0m58.148s
user    0m0.668s
sys     0m0.800s

$ time curl 'https://catalog.data.gov/csw' -d '<csw:GetRecords xmlns:csw
="http://www.opengis.net/cat/csw/2.0.2" xmlns:ogc="http://www.opengis.net/ogc" service="C
SW" version="2.0.2" resultType="results" startPosition="1" maxRecords="1000" outputFormat
="application/xml" outputSchema="http://www.isotc211.org/2005/gmd" xmlns:xsi="http://www.
w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/cat/csw/2.0.2
http://schemas.opengis.net/csw/2.0.2/CSW-discovery.xsd">
  <csw:Query typeNames="csw:Record">
    <csw:ElementSetName>full</csw:ElementSetName>
  </csw:Query>
</csw:GetRecords>' > /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 38.8M    0 38.8M  100   557   923k     12  0:00:46  0:00:43  0:00:03 1063k

real    0m43.135s
user    0m0.484s
sys     0m0.664s
```