### PR TITLE
Hotfix: [catalog] use in-memory sessions for catalog-web (staging)

### DIFF
--- a/ansible/inventories/production/group_vars/catalog-web/vars.yml
+++ b/ansible/inventories/production/group_vars/catalog-web/vars.yml
@@ -1,4 +1,6 @@
 ---
+ckan_session_store_type: memory
+
 # role url
 url_readonly: "{{ urls_public.catalog }}"
 url_writable: https://admin-catalog.data.gov

--- a/ansible/inventories/production/host_vars/catalogpub-web1p.prod-ocsit.bsp.gsa.gov/vars.yml
+++ b/ansible/inventories/production/host_vars/catalogpub-web1p.prod-ocsit.bsp.gsa.gov/vars.yml
@@ -1,3 +1,6 @@
+---
+ckan_session_store_type: ext:database
+
 # server readonly/writable type
 readwrite_type: writable
 

--- a/ansible/inventories/staging/group_vars/catalog-web/vars.yml
+++ b/ansible/inventories/staging/group_vars/catalog-web/vars.yml
@@ -1,4 +1,6 @@
 ---
+ckan_session_store_type: memory
+
 # role url
 url_readonly: "{{ urls_public.catalog }}"
 url_writable: https://admin-catalog-datagov.dev-ocsit.bsp.gsa.gov

--- a/ansible/inventories/staging/host_vars/catalogpub-web1d.dev-ocsit.bsp.gsa.gov/vars.yml
+++ b/ansible/inventories/staging/host_vars/catalogpub-web1d.dev-ocsit.bsp.gsa.gov/vars.yml
@@ -1,3 +1,6 @@
+---
+ckan_session_store_type: ext:database
+
 # server readonly/writable type
 readwrite_type: writable
 

--- a/ansible/roles/software/catalog/ckan-app/templates/etc/ckan/production.ini.j2
+++ b/ansible/roles/software/catalog/ckan-app/templates/etc/ckan/production.ini.j2
@@ -41,7 +41,7 @@ beaker.session.key = ckan
 # time it generates a config file.
 beaker.session.secret = {{ ckan_instance_secret }}
 
-beaker.session.type=ext:database
+beaker.session.type={{ ckan_session_store_type | default('ext:database') }}
 beaker.session.cookie_expires=true
 beaker.session.url=%(sqlalchemy.url)s
 beaker.session.timeout=3000


### PR DESCRIPTION
catalog-web has read-only access to the database, so in case a session needs to
be written for whatever reason, we don't want it to fail.

https://github.com/GSA/datagov-deploy/issues/691