### PR TITLE
Harvest report

### DIFF
--- a/ansible/inventories/production/host_vars/catalog-harvester2p.prod-ocsit.bsp.gsa.gov/vars.yml
+++ b/ansible/inventories/production/host_vars/catalog-harvester2p.prod-ocsit.bsp.gsa.gov/vars.yml
@@ -1,0 +1,2 @@
+---
+catalog_harvest_enable_harvest_report: true

--- a/ansible/roles/software/ckan/catalog/harvest/defaults/main.yml
+++ b/ansible/roles/software/ckan/catalog/harvest/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-
+catalog_harvest_enable_harvest_report: false
 saxon_license: license

--- a/ansible/roles/software/ckan/catalog/harvest/defaults/main.yml
+++ b/ansible/roles/software/ckan/catalog/harvest/defaults/main.yml
@@ -1,3 +1,6 @@
 ---
+catalog_ckan_db_host: localhost
+catalog_ckan_db_name: ckan
+catalog_ckan_db_user: ckan
 catalog_harvest_enable_harvest_report: false
 saxon_license: license

--- a/ansible/roles/software/ckan/catalog/harvest/molecule/default/playbook.yml
+++ b/ansible/roles/software/ckan/catalog/harvest/molecule/default/playbook.yml
@@ -3,3 +3,5 @@
   hosts: all
   roles:
     - role: harvest
+      vars:
+        catalog_ckan_db_pass: pass

--- a/ansible/roles/software/ckan/catalog/harvest/molecule/default/playbook.yml
+++ b/ansible/roles/software/ckan/catalog/harvest/molecule/default/playbook.yml
@@ -5,3 +5,4 @@
     - role: harvest
       vars:
         catalog_ckan_db_pass: pass
+        datagov_team_email: team@example.com

--- a/ansible/roles/software/ckan/catalog/harvest/molecule/misc_worker/playbook.yml
+++ b/ansible/roles/software/ckan/catalog/harvest/molecule/misc_worker/playbook.yml
@@ -3,3 +3,5 @@
   hosts: all
   roles:
     - role: harvest
+      vars:
+        catalog_ckan_db_pass: pass

--- a/ansible/roles/software/ckan/catalog/harvest/molecule/misc_worker/playbook.yml
+++ b/ansible/roles/software/ckan/catalog/harvest/molecule/misc_worker/playbook.yml
@@ -5,3 +5,4 @@
     - role: harvest
       vars:
         catalog_ckan_db_pass: pass
+        datagov_team_email: team@example.com

--- a/ansible/roles/software/ckan/catalog/harvest/molecule/qa_worker/playbook.yml
+++ b/ansible/roles/software/ckan/catalog/harvest/molecule/qa_worker/playbook.yml
@@ -3,3 +3,5 @@
   hosts: all
   roles:
     - role: harvest
+      vars:
+        catalog_ckan_db_pass: pass

--- a/ansible/roles/software/ckan/catalog/harvest/molecule/qa_worker/playbook.yml
+++ b/ansible/roles/software/ckan/catalog/harvest/molecule/qa_worker/playbook.yml
@@ -5,3 +5,4 @@
     - role: harvest
       vars:
         catalog_ckan_db_pass: pass
+        datagov_team_email: team@example.com

--- a/ansible/roles/software/ckan/catalog/harvest/tasks/main.yml
+++ b/ansible/roles/software/ckan/catalog/harvest/tasks/main.yml
@@ -64,6 +64,7 @@
   cron: >-
     cron_file=ckan
     job=/usr/local/bin/harvest-report.sh
-    disabled={{ !catalog_harvest_enable_harvest_report }}
+    disabled={{ not catalog_harvest_enable_harvest_report }}
     special_time=daily
+    user=root
     state=present

--- a/ansible/roles/software/ckan/catalog/harvest/tasks/main.yml
+++ b/ansible/roles/software/ckan/catalog/harvest/tasks/main.yml
@@ -46,3 +46,24 @@
   with_items:
     - usr/bin/celery-mem-check.sh
   when: worker_type == 'qa_worker'
+
+- name: install harvest-report script
+  template: src=harvest-report.sh.j2 dest=/usr/local/bin/harvest-report.sh owner=root group=root mode=0755
+
+- name: install pgpass file for harvest-report
+  copy:
+    content: |
+      {{ catalog_ckan_db_host }}:5432:{{ catalog_ckan_db_name }}:{{ catalog_ckan_db_user }}:{{ catalog_ckan_db_pass }}
+    # TODO should be an app user variable
+    dest: /root/.pgpass
+    mode: "0600"
+    owner: root
+    group: root
+
+- name: schedule harvest-report cron
+  cron: >-
+    cron_file=ckan
+    job=/usr/local/bin/harvest-report.sh
+    disabled={{ !catalog_harvest_enable_harvest_report }}
+    special_time=daily
+    state=present

--- a/ansible/roles/software/ckan/catalog/harvest/templates/harvest-report.sh.j2
+++ b/ansible/roles/software/ckan/catalog/harvest/templates/harvest-report.sh.j2
@@ -33,7 +33,7 @@ UNION
 ORDER BY "#";
 
 
-SELECT j.id, s.title, s.description, j.created, j.gather_started, j.gather_finished, j.finished, j.status
+SELECT j.id, j.created, s.title, s.description, j.gather_started, j.gather_finished, j.finished, j.status
 FROM harvest_job as j, harvest_source as s
 WHERE j.status = 'Running' AND j.source_id = s.id
 ORDER BY created;

--- a/ansible/roles/software/ckan/catalog/harvest/templates/harvest-report.sh.j2
+++ b/ansible/roles/software/ckan/catalog/harvest/templates/harvest-report.sh.j2
@@ -14,28 +14,28 @@ function cleanup() {
 
 trap cleanup EXIT
 
-job_count=$(psql -At -h {{ catalog_ckan_db_host }} -U {{ catalog_ckan_db_user }} --set ON_ERROR_STOP=1 {{ catalog_ckan_db_name }} -c 'SELECT count(*) from harvest_job')
+job_count=$(psql -At -h {{ catalog_ckan_db_host }} -U {{ catalog_ckan_db_user }} --set ON_ERROR_STOP=1 {{ catalog_ckan_db_name }} -c 'SELECT count(*) FROM harvest_job WHERE status = "Running";')
 if [[ "$job_count" -eq 0 ]]; then
   # nothing to report, exit ok
   exit 0
 fi
 
 psql -a -h {{ catalog_ckan_db_host }} -U {{ catalog_ckan_db_user }} --set ON_ERROR_STOP=1 {{ catalog_ckan_db_name }} <<SQL > $report_file
-(SELECT 1 as "#", 'created' as stage, count(*) as count, MIN(created) as oldest FROM harvest_job  WHERE status <> 'Finished' AND gather_started IS NULL)
+(SELECT 1 as "#", 'created' as stage, count(*) as count, MIN(created) as oldest FROM harvest_job  WHERE status = 'Running' AND gather_started IS NULL)
 UNION
-(SELECT 2 as "#", 'gathering' as stage, count(*) as count, MIN(gather_started) as oldest FROM harvest_job  WHERE status <> 'Finished' AND gather_started IS NOT NULL AND gather_finished IS NULL)
+(SELECT 2 as "#", 'gathering' as stage, count(*) as count, MIN(gather_started) as oldest FROM harvest_job  WHERE status = 'Running' AND gather_started IS NOT NULL AND gather_finished IS NULL)
 UNION
-(SELECT 3 as "#", 'gathered' as stage, count(*) as count, MIN(gather_finished) as oldest FROM harvest_job  WHERE status <> 'Finished' AND gather_finished IS NOT NULL AND finished IS NULL)
+(SELECT 3 as "#", 'gathered' as stage, count(*) as count, MIN(gather_finished) as oldest FROM harvest_job  WHERE status = 'Running' AND gather_finished IS NOT NULL AND finished IS NULL)
 UNION
-(SELECT 4 as "#", 'fetched' as stage, count(*) as count, MIN(finished) as oldest FROM harvest_job  WHERE status <> 'Finished' AND finished IS NOT NULL)
+(SELECT 4 as "#", 'fetched' as stage, count(*) as count, MIN(finished) as oldest FROM harvest_job  WHERE status = 'Running' AND finished IS NOT NULL)
 UNION
-(SELECT 5 as "#", 'total running' as stage, count(*) as count, MIN(created) as oldest FROM harvest_job  WHERE status <> 'Finished')
+(SELECT 5 as "#", 'total running' as stage, count(*) as count, MIN(created) as oldest FROM harvest_job  WHERE status = 'Running')
 ORDER BY "#";
 
 
 SELECT j.id, s.title, s.description, j.created, j.gather_started, j.gather_finished, j.finished, j.status
 FROM harvest_job as j, harvest_source as s
-WHERE j.status <> 'Finished' AND j.source_id = s.id
+WHERE j.status = 'Running' AND j.source_id = s.id
 ORDER BY created;
 SQL
 

--- a/ansible/roles/software/ckan/catalog/harvest/templates/harvest-report.sh.j2
+++ b/ansible/roles/software/ckan/catalog/harvest/templates/harvest-report.sh.j2
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+job_name=harvest-report
+report_file=$(mktemp)
+day=$(date +%Y-%m-%d)
+
+function cleanup() {
+  rm -rf "$report_file"
+}
+
+trap cleanup EXIT
+
+psql -h {{ catalog_ckan_db_host }} -U {{ catalog_ckan_db_user }} --set ON_ERROR_STOP=1 {{ catalog_ckan_db_name }} <<SQL > $report_file
+SELECT * FROM harvest_job WHERE status <> 'Finished' ORDER BY created;
+SQL
+
+if [[ "$(wc -l "$report_file" | cut -d' ' -f1)" -lt 2 ]]; then
+  # no conent in the report, exit ok
+  exit 0
+fi
+
+mail -s "[$job_name] In-progress harvest job report for $day" -a "From: no-reply+${job_name}@data.gov" {{ datagov_team_email }} <<EOF
+Hello, this is a daily report for harvest jobs in progress on ${day}.
+
+$(cat "$report_file")
+
+--
+$(basename "$0") on $(hostname)
+https://github.com/GSA/datagov-deploy
+EOF

--- a/ansible/roles/software/ckan/catalog/harvest/templates/harvest-report.sh.j2
+++ b/ansible/roles/software/ckan/catalog/harvest/templates/harvest-report.sh.j2
@@ -14,17 +14,35 @@ function cleanup() {
 
 trap cleanup EXIT
 
-psql -h {{ catalog_ckan_db_host }} -U {{ catalog_ckan_db_user }} --set ON_ERROR_STOP=1 {{ catalog_ckan_db_name }} <<SQL > $report_file
-SELECT * FROM harvest_job WHERE status <> 'Finished' ORDER BY created;
-SQL
-
-if [[ "$(wc -l "$report_file" | cut -d' ' -f1)" -lt 2 ]]; then
-  # no conent in the report, exit ok
+job_count=$(psql -At -h {{ catalog_ckan_db_host }} -U {{ catalog_ckan_db_user }} --set ON_ERROR_STOP=1 {{ catalog_ckan_db_name }} -c 'SELECT count(*) from harvest_job')
+if [[ "$job_count" -eq 0 ]]; then
+  # nothing to report, exit ok
   exit 0
 fi
 
+psql -a -h {{ catalog_ckan_db_host }} -U {{ catalog_ckan_db_user }} --set ON_ERROR_STOP=1 {{ catalog_ckan_db_name }} <<SQL > $report_file
+(SELECT 1 as "#", 'created' as stage, count(*) as count, MIN(created) as oldest FROM harvest_job  WHERE status <> 'Finished' AND gather_started IS NULL)
+UNION
+(SELECT 2 as "#", 'gathering' as stage, count(*) as count, MIN(gather_started) as oldest FROM harvest_job  WHERE status <> 'Finished' AND gather_started IS NOT NULL AND gather_finished IS NULL)
+UNION
+(SELECT 3 as "#", 'gathered' as stage, count(*) as count, MIN(gather_finished) as oldest FROM harvest_job  WHERE status <> 'Finished' AND gather_finished IS NOT NULL AND finished IS NULL)
+UNION
+(SELECT 4 as "#", 'fetched' as stage, count(*) as count, MIN(finished) as oldest FROM harvest_job  WHERE status <> 'Finished' AND finished IS NOT NULL)
+UNION
+(SELECT 5 as "#", 'total running' as stage, count(*) as count, MIN(created) as oldest FROM harvest_job  WHERE status <> 'Finished')
+ORDER BY "#";
+
+
+SELECT j.id, s.title, s.description, j.created, j.gather_started, j.gather_finished, j.finished, j.status
+FROM harvest_job as j, harvest_source as s
+WHERE j.status <> 'Finished' AND j.source_id = s.id
+ORDER BY created;
+SQL
+
 mail -s "[$job_name] In-progress harvest job report for $day" -a "From: no-reply+${job_name}@data.gov" {{ datagov_team_email }} <<EOF
-Hello, this is a daily report for harvest jobs in progress on ${day}.
+Hello team,
+
+This is a daily report for harvest jobs in progress on ${day}.
 
 $(cat "$report_file")
 

--- a/ansible/roles/software/ckan/catalog/harvest/templates/harvest-report.sh.j2
+++ b/ansible/roles/software/ckan/catalog/harvest/templates/harvest-report.sh.j2
@@ -14,7 +14,7 @@ function cleanup() {
 
 trap cleanup EXIT
 
-job_count=$(psql -At -h {{ catalog_ckan_db_host }} -U {{ catalog_ckan_db_user }} --set ON_ERROR_STOP=1 {{ catalog_ckan_db_name }} -c 'SELECT count(*) FROM harvest_job WHERE status = "Running";')
+job_count=$(psql -At -h {{ catalog_ckan_db_host }} -U {{ catalog_ckan_db_user }} --set ON_ERROR_STOP=1 {{ catalog_ckan_db_name }} -c $'SELECT count(*) FROM harvest_job WHERE status = \'Running\';')
 if [[ "$job_count" -eq 0 ]]; then
   # nothing to report, exit ok
   exit 0


### PR DESCRIPTION
Resolves #597 

Adds a daily report that summarizes in-progress harvest jobs. Includes the number of jobs in each harvest stage (created, gathering, gathered, fetched) and the oldest job in that stage. Additionally, the full list of in-progress jobs are listed to give a sense of the size of the queue.