### PR TITLE
Remove mariadb-client version specifier

### DIFF
--- a/ansible/roles/software/crm/crm-sudo-2-init/tasks/main.yml
+++ b/ansible/roles/software/crm/crm-sudo-2-init/tasks/main.yml
@@ -30,7 +30,7 @@
 - name: Installing required packages
   package: name={{ item }} state=installed
   with_items:
-    - mariadb-client-5.5
+    - mariadb-client
     - php7.0-zip
     - nginx-extras
 

--- a/ansible/roles/software/dashboard/dashboard-sudo-2-init/tasks/main.yml
+++ b/ansible/roles/software/dashboard/dashboard-sudo-2-init/tasks/main.yml
@@ -30,7 +30,7 @@
 - name: Installing required packages
   package: name={{ item }} state=installed
   with_items:
-    - mariadb-client-5.5
+    - mariadb-client
     - php7.1-mcrypt
     - php7.0-zip
     - nginx-extras

--- a/ansible/roles/software/wordpress/datagov-sudo-2-init/tasks/main.yml
+++ b/ansible/roles/software/wordpress/datagov-sudo-2-init/tasks/main.yml
@@ -39,7 +39,7 @@
 - name: Installing required packages
   package: name={{ item }} state=installed
   with_items:
-    - mariadb-client-5.5
+    - mariadb-client
     - php7.0-zip
     - nginx-extras
 


### PR DESCRIPTION
Use whatever OS provided version exists is fine.

This supports bionic hosts for crm and dashboard.