### PR TITLE
[catalog] reload supervisor on deploy

### DIFF
--- a/ansible/roles/software/ckan/catalog/ckan-app/handlers/main.yml
+++ b/ansible/roles/software/ckan/catalog/ckan-app/handlers/main.yml
@@ -2,3 +2,9 @@
 - name: reload apache2
   service: name=apache2 state=reloaded
   when: catalog_app_type == "web"
+
+- name: reload supervisor
+  command: supervisorctl reload
+  when: catalog_app_type == "worker"
+  tags:
+    - skip_ansible_lint

--- a/ansible/roles/software/ckan/catalog/ckan-app/tasks/main.yml
+++ b/ansible/roles/software/ckan/catalog/ckan-app/tasks/main.yml
@@ -45,20 +45,26 @@
 - name: Install CKAN app
   command: ./install.sh "{{ project_source_new_code_path }}" "{{ catalog_ckan_python_home }}" chdir={{ app_source_path }}
   tags: skip_ansible_lint
-  notify: reload apache2
+  notify:
+    - reload apache2
+    - reload supervisor
 
   # TODO instead of fixing the permissions after the fact, we should be using
   # the pip module with `umask` to install the requirements-freeze.txt
 - name: Fix permissions on ckan install dir
   file: owner=root group=www-data dest={{ project_source_new_code_path }} state=directory recurse=yes
-  notify: reload apache2
+  notify:
+    - reload apache2
+    - reload supervisor
 
 # Configure CKAN
 - name: Configure production.ini
   template: src=templates/{{ item }}.j2 dest=/{{ item }} owner=root group=www-data mode=0640
   with_items:
     - etc/ckan/production.ini
-  notify: reload apache2
+  notify:
+    - reload apache2
+    - reload supervisor
 
 # Add token.dat file
 - name: Add token.dat file
@@ -68,7 +74,9 @@
     owner=root
     group=www-data
     mode=0640
-  notify: reload apache2
+  notify:
+    - reload apache2
+    - reload supervisor
 
 - name: Configure who.ini
   copy:
@@ -78,7 +86,9 @@
     owner: root
     group: www-data
     mode: 0640
-  notify: reload apache2
+  notify:
+    - reload apache2
+    - reload supervisor
 
 - name: point site_url in /etc/hosts to localhost
   action: lineinfile dest=/etc/hosts line="127.0.0.1 {{ ckan_site_domain | regex_replace('https?\://','') }}"
@@ -90,4 +100,6 @@
     src: "{{ project_source_new_code_path }}"
     path: "{{ current_source_symlink }}"
     state: link
-  notify: reload apache2
+  notify:
+    - reload apache2
+    - reload supervisor

--- a/ansible/roles/software/ckan/catalog/harvest/handlers/main.yml
+++ b/ansible/roles/software/ckan/catalog/harvest/handlers/main.yml
@@ -2,7 +2,7 @@
   service: name=redis-server state=restarted
 
 - name: reload supervisor
-  command: supervisorctl reread
+  command: supervisorctl reload
   tags:
     - skip_ansible_lint
 

--- a/ansible/roles/software/ckan/catalog/pycsw-app/handlers/main.yml
+++ b/ansible/roles/software/ckan/catalog/pycsw-app/handlers/main.yml
@@ -2,3 +2,9 @@
 - name: reload apache2
   service: name=apache2 state=reloaded
   when: catalog_app_type == "web"
+
+- name: reload supervisor
+  command: supervisorctl reload
+  when: catalog_app_type == "worker"
+  tags:
+    - skip_ansible_lint

--- a/ansible/roles/software/ckan/catalog/pycsw-app/tasks/main.yml
+++ b/ansible/roles/software/ckan/catalog/pycsw-app/tasks/main.yml
@@ -8,7 +8,9 @@
 
 - name: run setup install for pycsw
   command: chdir=/usr/lib/ckan/src/pycsw/ /usr/lib/ckan/bin/python setup.py install
-  notify: reload apache2
+  notify:
+    - reload apache2
+    - reload supervisor
   tags: skip_ansible_lint
 
 - name: install pyproj
@@ -17,7 +19,9 @@
     version: 1.9.3
     virtualenv: "{{ pycsw_virtualenv }}"
     umask: "0022"
-  notify: reload apache2
+  notify:
+    - reload apache2
+    - reload supervisor
 
 - name: install geolinks
   pip:
@@ -25,7 +29,9 @@
     version: 0.2.0
     virtualenv: "{{ pycsw_virtualenv }}"
     umask: "0022"
-  notify: reload apache2
+  notify:
+    - reload apache2
+    - reload supervisor
 
 - name: copy pycsw configuration files
   copy:
@@ -35,13 +41,17 @@
   with_items:
     - etc/ckan/pycsw.wsgi
     - usr/lib/ckan/bin/pycsw-load.sh
-  notify: reload apache2
+  notify:
+    - reload apache2
+    - reload supervisor
 
 # TODO instead of fixing the permissions after the fact, we should be using
 # the pip module with `umask` to install the requirements-freeze.txt
 - name: Fix permissions on pycsw install dir
   file: owner=root group=www-data dest={{ pycsw_virtualenv }} state=directory recurse=yes
-  notify: reload apache2
+  notify:
+    - reload apache2
+    - reload supervisor
 
 - name: set facts1
   set_fact:
@@ -51,7 +61,9 @@
 
 - name: config pycsw-all.cfg
   template: src=pycsw-cfg.j2 dest=/etc/ckan/pycsw-all.cfg
-  notify: reload apache2
+  notify:
+    - reload apache2
+    - reload supervisor
 
 - name: set facts2
   set_fact:
@@ -61,7 +73,9 @@
 
 - name: config pycsw-collection.cfg
   template: src=pycsw-cfg.j2 dest=/etc/ckan/pycsw-collection.cfg
-  notify: reload apache2
+  notify:
+    - reload apache2
+    - reload supervisor
 
 - name: copy pycsw configuration files
   copy: src={{ item }} dest=/{{ item }} mode=0644


### PR DESCRIPTION
When new code is deployed, harvester processes need to be restarted.