### PR TITLE
[inventory] update who.timeout to match beaker

### DIFF
--- a/ansible/roles/software/ckan/inventory/templates/etc/ckan/production.ini
+++ b/ansible/roles/software/ckan/inventory/templates/etc/ckan/production.ini
@@ -50,8 +50,8 @@ app_instance_uuid = {{ ckan_instance_uuid }}
 who.config_file = %(here)s/who.ini
 who.log_level = warning
 who.log_file = %(cache_dir)s/who_log.ini
-# 30 minutes
-who.timeout = 900
+# 50 minutes to match beaker.session.timeout
+who.timeout = 3000
 # who.httponly = True # DEFAULT True already
 who.secure = {{ who_secure }}
 


### PR DESCRIPTION
Hoping to solve the issue of random logouts when browsing inventory pages.