### PR TITLE
Remove trusty jumpboxes from inventory

### DIFF
--- a/ansible/inventories/production/hosts
+++ b/ansible/inventories/production/hosts
@@ -67,7 +67,6 @@ jumpbox-v1
 jumpbox-v2
 
 [jumpbox-v1]
-datagov-jump1p.prod-ocsit.bsp.gsa.gov
 
 [jumpbox-v2]
 datagov-jump2p.prod-ocsit.bsp.gsa.gov

--- a/ansible/inventories/staging/hosts
+++ b/ansible/inventories/staging/hosts
@@ -61,7 +61,6 @@ jumpbox-v1
 jumpbox-v2
 
 [jumpbox-v1]
-datagov-jump1d.dev-ocsit.bsp.gsa.gov
 
 [jumpbox-v2]
 datagov-jump2d.dev-ocsit.bsp.gsa.gov


### PR DESCRIPTION
These hosts have been decommissioned.