### PR TITLE
Fix reboot playbook for bionic

### DIFF
--- a/ansible/actions/reboot.yml
+++ b/ansible/actions/reboot.yml
@@ -7,7 +7,9 @@
       register: reboot_required
 
     - name: Reboot host
-      command: reboot
+      shell: "sleep 1 && reboot"
+      async: 1
+      poll: 0
       when: force_reboot is defined or reboot_required.stat.exists
       register: rebooted
 


### PR DESCRIPTION
Bionic reboots quickly, and the reboot task fails, saying it cannot connect to
the host (although the host _is_ rebooted). This makes the task async which
prevents it from outright failing.

Fixes #804 