### PR TITLE
Bump gsa.datagov-deploy-common

### DIFF
--- a/ansible/roles/vendor/requirements.yml
+++ b/ansible/roles/vendor/requirements.yml
@@ -47,7 +47,7 @@
   version: v1.1.0
 - name: gsa.datagov-deploy-common
   src: https://github.com/GSA/datagov-deploy-common
-  version: v2.2.1
+  version: v2.2.2
 - name: gsa.datagov-deploy-jumpbox
   src: https://github.com/GSA/datagov-deploy-jumpbox
   version: v1.0.0


### PR DESCRIPTION
Pickup up fixes for GSA cert and systemd/supervisor install.