### PR TITLE
Remove /etc/hosts hack

### DIFF
--- a/ansible/roles/software/ckan/catalog/ckan-app/tasks/main.yml
+++ b/ansible/roles/software/ckan/catalog/ckan-app/tasks/main.yml
@@ -90,8 +90,9 @@
     - reload apache2
     - reload supervisor
 
-- name: point site_url in /etc/hosts to localhost
-  action: lineinfile dest=/etc/hosts line="127.0.0.1 {{ ckan_site_domain | regex_replace('https?\://','') }}"
+# TODO remove this after production deploy
+- name: undo point site_url in /etc/hosts to localhost
+  action: lineinfile dest=/etc/hosts line="127.0.0.1 {{ ckan_site_domain | regex_replace('https?\://','') }}" state=absent
   tags:
    - molecule-notest
 


### PR DESCRIPTION
pycsw-load job fails because it can't reach catalog on localhost
(catalog-harvester). Harvesters don't run web services so this is invalid. Just
use DNS, WAF, and caching just like any other request to catalog.