### PR TITLE
Set pycsw env for staging

### DIFF
--- a/ansible/inventories/staging/group_vars/all/vars.yml
+++ b/ansible/inventories/staging/group_vars/all/vars.yml
@@ -113,6 +113,7 @@ inventory_ckan_solr_port: "8983"
 nrinfragent_license_key: "{{ vault_nrinfragent_license_key }}"
 
 
+pycsw_app_environment: staging
 pycsw_app_version: datagov/v2.4.x
 pycsw_base_url: https://catalog-datagov.dev-ocsit.bsp.gsa.gov
 pycsw_catalog_url: https://catalog-datagov.dev-ocsit.bsp.gsa.gov


### PR DESCRIPTION
This enables the CA bundle so pycsw-load works in staging with GSA's certificate
authority signed certificates.