### PR TITLE
Bump dashboard test-kitchen to 18.04

### DIFF
--- a/ansible/.kitchen.yml
+++ b/ansible/.kitchen.yml
@@ -92,8 +92,9 @@ platforms:
  # Ubuntu XX with Upstart
   - name: ubuntu-18.04
     driver_config:
-      image: geerlingguy/docker-ubuntu1804-ansible
-      platform: ubuntu  
+      image: rndmh3ro/docker-ubuntu1804-ansible:latest
+      platform: ubuntu
+      provision_command: mkdir -p /run/sshd
 
 suites:
   - name: catalog-web

--- a/ansible/.kitchen.yml
+++ b/ansible/.kitchen.yml
@@ -89,10 +89,10 @@ provisioner:
   #ansible_verbosity: 2
 
 platforms:
- # Ubuntu Trusty with Upstart
-  - name: ubuntu-14.04
+ # Ubuntu XX with Upstart
+  - name: ubuntu-18.04
     driver_config:
-      image: rndmh3ro/docker-ubuntu1404-ansible:latest
+      image: geerlingguy/docker-ubuntu1804-ansible
       platform: ubuntu  
 
 suites:


### PR DESCRIPTION
`make test-kitchen-dashboard-web` fails w/ php 7.0 install errors unless w/ bump from 14.04.

the `mkdir -p /run/sshd` enables SSHD