### PR TITLE
Add sender_canonical_map to rewrite sender address for DMARC policy

### DIFF
--- a/ansible/inventories/production/group_vars/all/vars.yml
+++ b/ansible/inventories/production/group_vars/all/vars.yml
@@ -179,6 +179,14 @@ postfix_relaytls: true
 postfix_sasl_auth_enable: false
 postfix_smtpd_tls_cert_file: /etc/ssl/certs/datagov_host.crt
 postfix_smtpd_tls_key_file: /etc/ssl/certs/datagov_host.key
+postfix_aliases:
+  - user: postmaster
+    alias: root
+  - user: root
+    alias: "{{ datagov_team_email }}"
+postfix_sender_canonical_maps:
+  - sender: root
+    rewrite: no-reply+{{ ansible_fqdn }}@data.gov
 
 
 # SAML

--- a/ansible/inventories/staging/group_vars/all/vars.yml
+++ b/ansible/inventories/staging/group_vars/all/vars.yml
@@ -167,6 +167,16 @@ postfix_relaytls: true
 postfix_sasl_auth_enable: false
 postfix_smtpd_tls_cert_file: /etc/ssl/certs/datagov_host.crt
 postfix_smtpd_tls_key_file: /etc/ssl/certs/datagov_host.key
+postfix_aliases:
+  - user: postmaster
+    alias: root
+  - user: root
+    alias: "{{ datagov_team_email }}"
+postfix_sender_canonical_maps:
+  - sender: root
+    rewrite: no-reply+{{ ansible_fqdn }}@data.gov
+
+
 # SAML
 saml2_idp_entry: login.test.max.gov
 saml2_idp_metadata_url: "https://{{ saml2_idp_entry }}/idp/shibboleth"

--- a/ansible/roles/software/ckan/catalog/harvest/files/etc/cron.d/ckan_main_worker
+++ b/ansible/roles/software/ckan/catalog/harvest/files/etc/cron.d/ckan_main_worker
@@ -1,1 +1,1 @@
-*/3 * * * * root supervisorctl start harvest-run
+*/3 * * * * root supervisorctl start harvest-run > /dev/null

--- a/ansible/roles/software/ckan/catalog/harvest/files/etc/cron.d/ckan_misc_worker
+++ b/ansible/roles/software/ckan/catalog/harvest/files/etc/cron.d/ckan_misc_worker
@@ -1,7 +1,7 @@
-@monthly root supervisorctl start ckan-metrics-csv
+@monthly root supervisorctl start ckan-metrics-csv > /dev/null
 
 #1 1 * * * root supervisorctl start ckan-clean-deleted
-1 3 * * * root supervisorctl start ckan-tracking-update
+1 3 * * * root supervisorctl start ckan-tracking-update > /dev/null
 #30 23 * * * root supervisorctl start qa-update-sel:*
 #30 7 * * * root supervisorctl stop qa-update-sel:*
 #0 6 * * * root supervisorctl start ckan-report
@@ -9,7 +9,7 @@
 #30 5 * * * root supervisorctl start ckan-harvest-job-cleanup
 #30 4 * * * root supervisorctl start ckan-combine-feeds
 #2 2 * * * root supervisorctl start ckan-export-csv
-0 5 * * * root supervisorctl start ckan-sitemap
+0 5 * * * root supervisorctl start ckan-sitemap > /dev/null
 
 ## jsonl export on 3rd day of each month at 2:01 AM
 #1 2 3 * * root supervisorctl start ckan-jsonl-export

--- a/ansible/roles/software/ckan/catalog/harvest/files/etc/cron.d/ckan_qa_worker
+++ b/ansible/roles/software/ckan/catalog/harvest/files/etc/cron.d/ckan_qa_worker
@@ -1,1 +1,1 @@
-*/5 * * * * root supervosorctl start celery-mem-check
+*/5 * * * * root supervosorctl start celery-mem-check > /dev/null

--- a/ansible/roles/vendor/requirements.yml
+++ b/ansible/roles/vendor/requirements.yml
@@ -86,6 +86,6 @@
 - name: nleutner.newrelic-php
   version: 1.0.0
 - name: oefenweb.postfix
-  version: v2.7.1
+  version: v2.8.4
 - name: sbaerlocher.wp-cli
   version: 1.3.1


### PR DESCRIPTION
This updates the postfix configuration to map to
1. rewrite the sender address acceptable to DMARC so pretty much any mail is delivered
1. map root to the tech help email address

In effect, any email notification from all hosts will go to the tech team unless explicitly addressed otherwise.