### PR TITLE
Release fixes

### DIFF
--- a/ansible/catalog-web.yml
+++ b/ansible/catalog-web.yml
@@ -1,6 +1,6 @@
 ---
 - name: Provision Catalog databases
-  hosts: catalog-web
+  hosts: catalog-web,!v2
   pre_tasks:
     # Database initialization should be delegated to the jumpbox, however
     # jumpbox does not have access to the application databases (firewall/security
@@ -32,7 +32,7 @@
 
 
 - name: Catalog web stack
-  hosts: catalog-web
+  hosts: catalog-web,!v2
   serial: 1
   vars:
       app_type: catalog
@@ -67,21 +67,21 @@
         - frontend
 
 - name: NewRelic
-  hosts: catalog-web,!catalog-admin
+  hosts: catalog-web,!catalog-admin,!v2
   vars:
     newrelic_app_name: catalog
   roles:
     - monitoring/newrelic/python-agent-ansible
 
 - name: NewRelic
-  hosts: catalog-admin
+  hosts: catalog-admin,!v2
   vars:
-    newrelic_app_name: catalog-admin
+    newrelic_app_name: catalog-admin,!v2
   roles:
     - monitoring/newrelic/python-agent-ansible
 
 - name: Smoke test catalog
-  hosts: catalog-web,!catalog-admin
+  hosts: catalog-web,!catalog-admin,!v2
   tasks:
     - name: flush handlers
       meta: flush_handlers

--- a/ansible/catalog-worker.yml
+++ b/ansible/catalog-worker.yml
@@ -1,6 +1,6 @@
 ---
 - name: Catalog worker (harvester) stack
-  hosts: catalog-harvester
+  hosts: catalog-harvester,!v2
   vars:
       app_type: catalog
 
@@ -21,7 +21,7 @@
         - saml2
 
 - name: logrotate configuration
-  hosts: catalog-harvester
+  hosts: catalog-harvester,!v2
   roles:
     - role: nickhammond.logrotate
       logrotate_scripts:

--- a/ansible/datagov-web.yml
+++ b/ansible/datagov-web.yml
@@ -1,6 +1,6 @@
 ---
 - name: Deploy Wordpress
-  hosts:  "{{ datagov_web_hosts | default('wordpress-web') }}"
+  hosts: wordpress-web
   serial: 1
   roles:
   # TODO remove the die-no-tags role. You should be able to run a role playbook

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -1,6 +1,6 @@
 ---
 - name: Provision Inventory databases
-  hosts: inventory-web
+  hosts: inventory-web,!v2
   pre_tasks:
     # Database initialization should be delegated to the jumpbox, however
     # jumpbox does not have access to the application databases (firewall/security
@@ -52,7 +52,7 @@
 
 
 - name: Provisioning Inventory CKAN Stack
-  hosts: inventory-web
+  hosts: inventory-web,!v2
   serial: 1
   vars:
     app_type: inventory
@@ -65,14 +65,14 @@
     - {role: software/ckan/saml2, tags: ['saml2']}
 
 - name: NewRelic
-  hosts: inventory-web
+  hosts: inventory-web,!v2
   vars:
     newrelic_app_name: inventory
   roles:
     - monitoring/newrelic/python-agent-ansible
 
 - name: Smoke test inventory
-  hosts: inventory-web
+  hosts: inventory-web,!v2
   tasks:
     - name: flush handlers
       meta: flush_handlers

--- a/ansible/pycsw.yml
+++ b/ansible/pycsw.yml
@@ -1,6 +1,6 @@
 ---
 - name: Set the deploy version
-  hosts: pycsw-web,pycsw-worker
+  hosts: pycsw-web,pycsw-worker,!v2
   tasks:
     - name: Set deploy version
       set_fact:
@@ -30,7 +30,7 @@
     - database
 
 - name: CSW web
-  hosts: pycsw-web
+  hosts: pycsw-web,!v2
   serial: 1
   roles:
     - role: gsa.datagov-deploy-pycsw
@@ -39,7 +39,7 @@
     - pycsw
 
 - name: CSW worker
-  hosts: pycsw-worker
+  hosts: pycsw-worker,!v2
   roles:
     - role: gsa.datagov-deploy-pycsw
       pycsw_role: worker

--- a/ansible/roles/vendor/requirements.yml
+++ b/ansible/roles/vendor/requirements.yml
@@ -58,7 +58,7 @@
   version: v1.2.2
 - name: gsa.datagov-deploy-common
   src: https://github.com/GSA/datagov-deploy-common
-  version: v2.2.2
+  version: v2.2.3
 - name: gsa.datagov-deploy-jumpbox
   src: https://github.com/GSA/datagov-deploy-jumpbox
   version: v1.1.1


### PR DESCRIPTION
Some fixes needed to release to staging.

- Limit hosts to exclude v2 hosts for catalog/inventory (which are still WIP)
- Bump datagov-deploy-common which includes the fix for the removed jekyll-web inventory group