### PR TITLE
Update smoke tests

### DIFF
--- a/ansible/catalog-web.yml
+++ b/ansible/catalog-web.yml
@@ -30,7 +30,6 @@
       when: datagov_enable_postgresql_role is defined
 
 
-
 - name: Catalog web stack
   hosts: catalog-web,!v2
   serial: 1
@@ -41,30 +40,83 @@
     - role: software/common/tls
       tags:
         - tls
-
     - role: software/ckan/common
-
     - role: gsa.datagov-deploy-apache2
       tags:
         - apache
-
     - role: software/ckan/catalog/ckan-app
       vars:
         app_repo_branch: "{{ catalog_ckan_app_version }}"
       tags:
         - app-deploy
-
     - role: software/ckan/catalog/www
       tags:
         - apache2
-
     - role: software/ckan/saml2
       tags:
         - saml2
-
     - role: software/ckan/fix-ckan-tracking
       tags:
         - frontend
+
+  # Host-level smoke tests
+  tasks:
+    - name: flush handlers
+      meta: flush_handlers
+
+    - name: assert catalog is up
+      uri:
+        url: http://{{ ansible_fqdn }}/api/action/status_show
+        follow_redirects: none
+        status_code: 200
+        # TODO enable cert validation. Staging and production hosts have GSA
+        # signed certs which should be valid.
+        # https://github.com/GSA/datagov-deploy/issues/900
+        validate_certs: false
+        headers:
+          # For catalog-admin hosts
+          Cookie: auth_tkt=1
+
+    - name: assert csw-collection is up
+      uri:
+        url: http://{{ ansible_fqdn }}/csw?service=CSW&version=2.0.2&request=GetCapabilities
+        follow_redirects: none
+        status_code: 200
+        return_content: true
+        # TODO enable cert validation. Staging and production hosts have GSA
+        # signed certs which should be valid.
+        # https://github.com/GSA/datagov-deploy/issues/900
+        validate_certs: false
+        headers:
+          # For catalog-admin hosts
+          Cookie: auth_tkt=1
+      register: csw_collection
+
+    - name: assert csw-collection response has title
+      fail:
+        msg: csw-collection response did not contain ows:Title attribute
+      when: csw_collection.content is not search("<ows:Title>CSW interface for catalog.data.gov</ows:Title>")
+
+    - name: assert csw-all is up
+      uri:
+        url: http://{{ ansible_fqdn }}/csw-all?service=CSW&version=2.0.2&request=GetCapabilities
+        follow_redirects: none
+        status_code: 200
+        return_content: true
+        # TODO enable cert validation. Staging and production hosts have GSA
+        # signed certs which should be valid.
+        # https://github.com/GSA/datagov-deploy/issues/900
+        validate_certs: false
+        headers:
+          # For catalog-admin hosts
+          Cookie: auth_tkt=1
+      register: csw_all
+
+    - name: assert csw-all response has title
+      fail:
+        msg: csw-all response did not contain ows:Title attribute
+      when: csw_all.content is not search("<ows:Title>CSW interface for catalog.data.gov</ows:Title>")
+
 
 - name: NewRelic
   hosts: catalog-web,!catalog-admin,!v2
@@ -80,22 +132,29 @@
   roles:
     - monitoring/newrelic/python-agent-ansible
 
-- name: Smoke test catalog
-  hosts: catalog-web,!catalog-admin,!v2
+
+- name: Service-level smoke tests
+  hosts: catalog-web,!v2
   tasks:
     - name: flush handlers
       meta: flush_handlers
+
     - name: assert catalog is up
       uri:
-        url: http://{{ ansible_fqdn }}/
+        url: "{{ catalog_ckan_service_url }}/api/action/status_show"
+        follow_redirects: none
         status_code: 200
         # TODO enable cert validation. Staging and production hosts have GSA
         # signed certs which should be valid.
         # https://github.com/GSA/datagov-deploy/issues/900
         validate_certs: false
+      run_once: true
+      delegate_to: localhost
+
     - name: assert csw-collection is up
       uri:
-        url: http://{{ ansible_fqdn }}/csw?service=CSW&version=2.0.2&request=GetCapabilities
+        url: "{{ catalog_ckan_service_url }}/csw?service=CSW&version=2.0.2&request=GetCapabilities"
+        follow_redirects: none
         status_code: 200
         return_content: true
         # TODO enable cert validation. Staging and production hosts have GSA
@@ -103,14 +162,20 @@
         # https://github.com/GSA/datagov-deploy/issues/900
         validate_certs: false
       register: csw_collection
+      run_once: true
+      delegate_to: localhost
+
     - name: assert csw-collection response has title
       fail:
         msg: csw-collection response did not contain ows:Title attribute
       when: csw_collection.content is not search("<ows:Title>CSW interface for catalog.data.gov</ows:Title>")
+      run_once: true
+      delegate_to: localhost
 
     - name: assert csw-all is up
       uri:
-        url: http://{{ ansible_fqdn }}/csw-all?service=CSW&version=2.0.2&request=GetCapabilities
+        url: "{{ catalog_ckan_service_url }}/csw-all?service=CSW&version=2.0.2&request=GetCapabilities"
+        follow_redirects: none
         status_code: 200
         return_content: true
         # TODO enable cert validation. Staging and production hosts have GSA
@@ -118,7 +183,12 @@
         # https://github.com/GSA/datagov-deploy/issues/900
         validate_certs: false
       register: csw_all
+      run_once: true
+      delegate_to: localhost
+
     - name: assert csw-all response has title
       fail:
         msg: csw-all response did not contain ows:Title attribute
       when: csw_all.content is not search("<ows:Title>CSW interface for catalog.data.gov</ows:Title>")
+      run_once: true
+      delegate_to: localhost

--- a/ansible/crm-web.yml
+++ b/ansible/crm-web.yml
@@ -28,9 +28,34 @@
 - name: Cleanup
   hosts: crm-web
   serial: 1
+  tags: [deploy,provision]
   roles:
-  - { role: software/common/php-fixes, tags: [php, provision, deploy] }
-  - { role: software/crm/crm-sudo-3-cleanup, tags: [provision, deploy, deploy-rollback] }
+  - { role: software/common/php-fixes, tags: [php] }
+  - { role: software/crm/crm-sudo-3-cleanup, tags: [deploy-rollback] }
+
+  # TODO this should be closer to the deploy play
+  # Host-level smoke tests
+  tasks:
+    - name: flush handlers
+      meta: flush_handlers
+
+    - name: assert app is up
+      uri:
+        url: https://{{ ansible_fqdn }}/
+        follow_redirects: none
+        status_code: 200
+        # TODO enable cert validation. Staging and production hosts have GSA
+        # signed certs which should be valid.
+        # https://github.com/GSA/datagov-deploy/issues/900
+        validate_certs: false
+
+    - name: access to simplesaml admin is forbidden
+      uri:
+        url: https://{{ ansible_fqdn }}/simplesaml/module.php/core/loginuserpass.php
+        follow_redirects: none
+        status_code: 403
+        validate_certs: false
+
 
 - name: CRM Migration
   hosts: crm-web
@@ -39,23 +64,21 @@
   roles:
   - { role: software/crm/crm-migrations, tags: [provision, deploy, migrate] }
 
-- name: Smoke test CRM
+- name: Service-level smoke tests
   hosts: crm-web
+  tags: [deploy,provision]
   tasks:
     - name: flush handlers
       meta: flush_handlers
+
     - name: assert app is up
       uri:
-        url: https://{{ ansible_fqdn }}/
+        url: "{{ crm_service_url }}/"
+        follow_redirects: none
         status_code: 200
         # TODO enable cert validation. Staging and production hosts have GSA
         # signed certs which should be valid.
         # https://github.com/GSA/datagov-deploy/issues/900
         validate_certs: false
-      tags: [deploy,provision]
-    - name: access to simplesaml admin is forbidden
-      uri:
-        url: https://{{ ansible_fqdn }}/simplesaml/module.php/core/loginuserpass.php
-        status_code: 403
-        validate_certs: false
-      tags: [deploy,provision]
+      run_once: true
+      delegate_to: localhost

--- a/ansible/dashboard-web.yml
+++ b/ansible/dashboard-web.yml
@@ -32,6 +32,28 @@
   - { role: software/common/php-fixes, tags: [php, provision, deploy] }
   - { role: software/dashboard/dashboard-sudo-3-cleanup, tags: [provision, deploy, deploy-rollback] }
 
+  # TODO move these closer to the deploy play
+  # Host-level smoke tests
+  tasks:
+    - name: flush handlers
+      meta: flush_handlers
+
+    - name: assert app is up
+      uri:
+        url: https://{{ ansible_fqdn }}/offices/qa
+        follow_redirects: none
+        status_code: 200
+        # TODO enable cert validation. Staging and production hosts have GSA
+        # signed certs which should be valid.
+        # https://github.com/GSA/datagov-deploy/issues/900
+        validate_certs: false
+
+    - name: access to simplesaml admin is forbidden
+      uri:
+        url: https://{{ ansible_fqdn }}/simplesaml/module.php/core/loginuserpass.php
+        follow_redirects: none
+        status_code: 403
+        validate_certs: false
 
 
 - name: Dashboard DB Migration
@@ -41,23 +63,21 @@
   roles:
   - { role: software/dashboard/dashboard-db-migrations, tags: [provision, deploy, migrate] }
 
-- name: Smoke test dashboard
+- name: Service-level smoke tests for dashboard
   hosts: dashboard-web
+  tags: [deploy,provision]
   tasks:
     - name: flush handlers
       meta: flush_handlers
+
     - name: assert app is up
       uri:
-        url: https://{{ ansible_fqdn }}/
+        url: "{{ dashboard_service_url }}/offices/qa"
+        follow_redirects: none
         status_code: 200
         # TODO enable cert validation. Staging and production hosts have GSA
         # signed certs which should be valid.
         # https://github.com/GSA/datagov-deploy/issues/900
         validate_certs: false
-      tags: [deploy,provision]
-    - name: access to simplesaml admin is forbidden
-      uri:
-        url: https://{{ ansible_fqdn }}/simplesaml/module.php/core/loginuserpass.php
-        status_code: 403
-        validate_certs: false
-      tags: [deploy,provision]
+      run_once: true
+      delegate_to: localhost

--- a/ansible/datagov-web.yml
+++ b/ansible/datagov-web.yml
@@ -28,29 +28,33 @@
 - name: Cleanup
   hosts: wordpress-web
   serial: 1
+  tags: [provision, deploy]
   roles:
-  - { role: software/common/php-fixes, tags: [php, provision, deploy] }
-  - { role: software/wordpress/datagov-sudo-3-cleanup, tags: [provision, deploy, deploy-rollback, cleanup] }
+  - { role: software/common/php-fixes, tags: [php] }
+  - { role: software/wordpress/datagov-sudo-3-cleanup, tags: [deploy-rollback, cleanup] }
 
-- name: Smoke tests
-  hosts: wordpress-web
+  # TODO these should happen closer to the deploy play
+  # Host-level smoke tests
   tasks:
     - name: flush handlers
       meta: flush_handlers
+
     - name: assert app is up
       uri:
         url: https://{{ ansible_fqdn }}/
+        follow_redirects: none
         status_code: 200
         # TODO enable cert validation. Staging and production hosts have GSA
         # signed certs which should be valid.
         # https://github.com/GSA/datagov-deploy/issues/900
         validate_certs: false
-      tags: [deploy,provision]
+
     - name: assert access to simplesaml admin is forbidden
       uri:
         url: https://{{ ansible_fqdn }}/app/plugins/saml-20-single-sign-on/saml/www/module.php/core/loginuserpass.php
         status_code: 403
         validate_certs: false
+
     - name: assert CRM forms should redirect to general contact form
       uri:
         url: https://{{ ansible_fqdn }}/{{ item }}
@@ -62,6 +66,7 @@
         - issue
         - story
       register: contact_forms
+
     - name: assert Location header contains /contact
       fail:
         msg: "Expected Location {{ expected_url }} to be in {{ item.location }}"
@@ -69,4 +74,23 @@
       vars:
         expected_url: "{{ ansible_fqdn }}/contact"
       loop: "{{ contact_forms.results }}"
+
+
+- name: Service-level smoke tests
+  hosts: wordpress-web
   tags: [deploy,provision]
+  tasks:
+    - name: flush handlers
+      meta: flush_handlers
+
+    - name: assert app is up
+      uri:
+        url: "{{ wordpress_service_url }}/"
+        follow_redirects: none
+        status_code: 200
+        # TODO enable cert validation. Staging and production hosts have GSA
+        # signed certs which should be valid.
+        # https://github.com/GSA/datagov-deploy/issues/900
+        validate_certs: false
+      run_once: true
+      delegate_to: localhost

--- a/ansible/inventories/bionic/group_vars/all/vars.yml
+++ b/ansible/inventories/bionic/group_vars/all/vars.yml
@@ -33,6 +33,10 @@ trendmicro_enabled: false
 crm_service_url: https://crm.bionic.datagov.us
 
 
+# dashboard
+dashboard_service_url: https://dashboard.bionic.datagov.us
+
+
 datagov_enable_postgresql_role: true
 datagov_environment: bionic
 

--- a/ansible/inventories/bionic/group_vars/all/vars.yml
+++ b/ansible/inventories/bionic/group_vars/all/vars.yml
@@ -123,3 +123,6 @@ saml2_sp_private_pem: "{{ default_tls_host_certificate }}"
 # ckan
 # Auth cookie `auth_tkt` must be HTTPS-only (SECURE) on Production
 who_secure: True
+
+# wordpress
+wordpress_service_url: https://wordpress.bionic.data.gov

--- a/ansible/inventories/bionic/group_vars/all/vars.yml
+++ b/ansible/inventories/bionic/group_vars/all/vars.yml
@@ -29,6 +29,10 @@ nessus_agent_enabled: false
 trendmicro_enabled: false
 
 
+# crm
+crm_service_url: https://crm.bionic.datagov.us
+
+
 datagov_enable_postgresql_role: true
 datagov_environment: bionic
 

--- a/ansible/inventories/bionic/group_vars/all/vars.yml
+++ b/ansible/inventories/bionic/group_vars/all/vars.yml
@@ -7,6 +7,7 @@ catalog_ckan_db_pass: "{{ vault_catalog_ckan_db_pass }}"
 catalog_ckan_db_user: ckan
 catalog_ckan_redis_host: catalog-harvester1tf.internal.bionic.datagov.us
 catalog_ckan_redis_pass: "{{ vault_catalog_ckan_redis_pass }}"
+catalog_ckan_service_url: https://catalog.bionic.datagov.us
 catalog_ckan_solr_host: datagovsolr1tf.internal.bionic.datagov.us
 catalog_ckan_solr_port: "{{ solr_port }}"
 catalog_postgresql_login_host: "{{ vault_catalog_postgresql_login_host }}"
@@ -66,6 +67,7 @@ jumpbox_operators: "{{ vault_jumpbox_operators }}"
 
 
 inventory_ckan_app_version: inventory-bionic
+inventory_ckan_service_url: https://inventory.bionic.datagov.us
 inventory_ckan_solr_port: "{{ solr_port }}"
 
 pycsw_app_version: datagov/v2.4.x

--- a/ansible/inventories/ci/group_vars/all/vars.yml
+++ b/ansible/inventories/ci/group_vars/all/vars.yml
@@ -137,3 +137,7 @@ secops_user_public_key: "{{ vault_secops_user_public_key }}"
 solr_master_server: datagovsolr1tf.internal.{{ datagov_sandbox_env }}.datagov.us
 solr_java_packages:
   - openjdk-7-jdk
+
+
+# wordpress
+wordpress_service_url: https://wordpress.ci.datagov.us

--- a/ansible/inventories/ci/group_vars/all/vars.yml
+++ b/ansible/inventories/ci/group_vars/all/vars.yml
@@ -30,6 +30,10 @@ nessus_agent_enabled: false
 trendmicro_enabled: false
 
 
+# crm
+crm_service_url: https://crm.ci.datagov.us
+
+
 # data.gov-wide variables
 datagov_enable_postgresql_role: true
 datagov_environment: ci

--- a/ansible/inventories/ci/group_vars/all/vars.yml
+++ b/ansible/inventories/ci/group_vars/all/vars.yml
@@ -34,6 +34,10 @@ trendmicro_enabled: false
 crm_service_url: https://crm.ci.datagov.us
 
 
+# dashboard
+dashboard_service_url: https://dashboard.ci.datagov.us
+
+
 # data.gov-wide variables
 datagov_enable_postgresql_role: true
 datagov_environment: ci

--- a/ansible/inventories/ci/group_vars/all/vars.yml
+++ b/ansible/inventories/ci/group_vars/all/vars.yml
@@ -7,6 +7,7 @@ catalog_ckan_db_pass: "{{ vault_catalog_ckan_db_pass }}"
 catalog_ckan_db_user: ckan
 catalog_ckan_redis_host: catalog-harvester1tf.internal.ci.datagov.us
 catalog_ckan_redis_pass: "{{ vault_catalog_ckan_redis_pass }}"
+catalog_ckan_service_url: https://catalog.ci.datagov.us
 catalog_ckan_solr_host: datagovsolr1tf.internal.ci.datagov.us
 catalog_ckan_solr_port: "{{ solr_port }}"
 catalog_postgresql_login_host: "{{ vault_catalog_postgresql_login_host }}"
@@ -67,6 +68,7 @@ default_tls_host_certificate: |-
 jumpbox_operators: "{{ vault_jumpbox_operators }}"
 
 
+inventory_ckan_service_url: https://inventory.ci.datagov.us
 inventory_ckan_solr_port: "{{ solr_port }}"
 
 

--- a/ansible/inventories/production/group_vars/all/vars.yml
+++ b/ansible/inventories/production/group_vars/all/vars.yml
@@ -8,6 +8,7 @@ catalog_ckan_db_pass: "{{ vault_catalog_ckan_db_pass }}"
 catalog_ckan_db_user: "{{ vault_catalog_ckan_db_user }}"
 catalog_ckan_harvest_fetch_process_count: 6
 catalog_ckan_qa_update_process_count: 5
+catalog_ckan_service_url: https://catalog.data.gov
 catalog_ckan_solr_port: "8983"
 catalog_ckan_solr_host: datagov-solr1p.prod-ocsit.bsp.gsa.gov
 catalog_pycsw_db_host: "{{ vault_catalog_pycsw_db_host }}"
@@ -114,6 +115,7 @@ default_tls_host_certificate: |-
 jumpbox_operators: "{{ vault_jumpbox_operators }}"
 
 
+inventory_ckan_service_url: https://inventory.data.gov
 inventory_ckan_solr_host: datagov-solrm1p.prod-ocsit.bsp.gsa.gov
 inventory_ckan_solr_port: "8983"
 

--- a/ansible/inventories/production/group_vars/all/vars.yml
+++ b/ansible/inventories/production/group_vars/all/vars.yml
@@ -45,6 +45,10 @@ products:
 crm_service_url: https://labs.data.gov/crm
 
 
+# dashboard
+dashboard_service_url: https://labs.data.gov/dashboard
+
+
 # data.gov-wide variables
 datagov_environment: production
 

--- a/ansible/inventories/production/group_vars/all/vars.yml
+++ b/ansible/inventories/production/group_vars/all/vars.yml
@@ -41,6 +41,10 @@ products:
   - filebeat
 
 
+# crm
+crm_service_url: https://labs.data.gov/crm
+
+
 # data.gov-wide variables
 datagov_environment: production
 

--- a/ansible/inventories/production/group_vars/all/vars.yml
+++ b/ansible/inventories/production/group_vars/all/vars.yml
@@ -215,3 +215,6 @@ who_secure: True
 ci_inventory: inventories/production
 ci_ssh_config_host: '*.prod-ocsit.bsp.gsa.gov'
 ci_deploy_version: master
+
+
+wordpress_service_url: https://www.data.gov

--- a/ansible/inventories/staging/group_vars/all/vars.yml
+++ b/ansible/inventories/staging/group_vars/all/vars.yml
@@ -45,6 +45,9 @@ products:
 # crm
 crm_service_url: https://crm-datagov.dev-ocsit.bsp.gsa.gov
 
+# dashboard
+dashboard_service_url: https://dashboard-datagov.dev-ocsit.bsp.gsa.gov
+
 # data.gov-wide variables
 datagov_environment: staging
 

--- a/ansible/inventories/staging/group_vars/all/vars.yml
+++ b/ansible/inventories/staging/group_vars/all/vars.yml
@@ -9,6 +9,7 @@ catalog_ckan_db_pass: "{{ vault_catalog_ckan_db_pass }}"
 catalog_ckan_db_user: "{{ vault_catalog_ckan_db_user }}"
 catalog_ckan_harvest_fetch_process_count: 6
 catalog_ckan_qa_update_process_count: 5
+catalog_ckan_service_url: https://catalog-datagov.dev-ocsit.bsp.gsa.gov
 catalog_ckan_solr_host: datagov-solr1d.dev-ocsit.bsp.gsa.gov
 catalog_ckan_solr_port: "8983"
 # read-only database variables
@@ -105,6 +106,7 @@ default_tls_host_certificate: |-
 jumpbox_operators: "{{ vault_jumpbox_operators }}"
 
 
+inventory_ckan_service_url: https://inventory-datagov.dev-ocsit.bsp.gsa.gov
 inventory_ckan_solr_host: datagov-solrm1d.dev-ocsit.bsp.gsa.gov
 inventory_ckan_solr_port: "8983"
 

--- a/ansible/inventories/staging/group_vars/all/vars.yml
+++ b/ansible/inventories/staging/group_vars/all/vars.yml
@@ -204,3 +204,5 @@ users: "{{ vault_users }}"
 ci_inventory: inventories/staging
 ci_ssh_config_host: '*.dev-ocsit.bsp.gsa.gov'
 ci_deploy_version: develop
+
+wordpress_service_url: https://wordpress-datagov.dev-ocsit.bsp.gsa.gov

--- a/ansible/inventories/staging/group_vars/all/vars.yml
+++ b/ansible/inventories/staging/group_vars/all/vars.yml
@@ -42,6 +42,8 @@ filebeat_config: "{{ common_filebeat_config }}"
 products:
   - filebeat
 
+# crm
+crm_service_url: https://crm-datagov.dev-ocsit.bsp.gsa.gov
 
 # data.gov-wide variables
 datagov_environment: staging

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -64,6 +64,22 @@
     - {role: software/ckan/inventory, tags: ['deploy']}
     - {role: software/ckan/saml2, tags: ['saml2']}
 
+  # Host-level smoke tests
+  tasks:
+    - name: flush handlers
+      meta: flush_handlers
+
+    - name: assert app is up
+      uri:
+        url: http://{{ ansible_fqdn }}/api/action/status_show
+        follow_redirects: none
+        status_code: 200
+        # TODO enable cert validation. Staging and production hosts have GSA
+        # signed certs which should be valid.
+        # https://github.com/GSA/datagov-deploy/issues/900
+        validate_certs: false
+
+
 - name: NewRelic
   hosts: inventory-web,!v2
   vars:
@@ -71,16 +87,24 @@
   roles:
     - monitoring/newrelic/python-agent-ansible
 
-- name: Smoke test inventory
+
+- name: Service-level smoke tests
   hosts: inventory-web,!v2
   tasks:
     - name: flush handlers
       meta: flush_handlers
-    - name: assert app is up
+
+    - name: assert inventory service is available
       uri:
-        url: http://{{ ansible_fqdn }}/
+        url: "{{ inventory_ckan_service_url }}/api/action/status_show"
+        follow_redirects: none
         status_code: 200
         # TODO enable cert validation. Staging and production hosts have GSA
         # signed certs which should be valid.
         # https://github.com/GSA/datagov-deploy/issues/900
         validate_certs: false
+        headers:
+          # Avoid login redirect
+          Cookie: auth_tkt=1
+      run_once: true
+      delegate_to: localhost


### PR DESCRIPTION
- Add a service-level smoke test (at the public url)
- Move the host-level tests closer to deploy to  prevent a bad deploy earlier
- Use more specific URLs that better indicate the health of the service
- Don't follow redirects in assertions so that we know exactly what we're testing