### PR TITLE
Update logging configuration for CKAN

### DIFF
--- a/ansible/catalog-web.yml
+++ b/ansible/catalog-web.yml
@@ -118,6 +118,23 @@
       when: csw_all.content is not search("<ows:Title>CSW interface for catalog.data.gov</ows:Title>")
 
 
+- name: logrotate configuration
+  hosts: catalog-web,!v2
+  roles:
+    - role: nickhammond.logrotate
+      logrotate_scripts:
+        - name: inventory
+          paths:
+            - /var/log/ckan/ckan.error.log
+            - /var/log/ckan/ckan.access.log
+          options:
+            - compress
+            - copytruncate
+            - size 512M
+            - missingok
+            - rotate 8
+
+
 - name: NewRelic
   hosts: catalog-web,!catalog-admin,!v2
   vars:

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -80,6 +80,22 @@
         validate_certs: false
 
 
+- name: logrotate configuration
+  hosts: inventory-web,!v2
+  roles:
+    - role: nickhammond.logrotate
+      logrotate_scripts:
+        - name: inventory
+          paths:
+            - /var/log/inventory/*
+          options:
+            - compress
+            - copytruncate
+            - weekly
+            - missingok
+            - rotate 8
+
+
 - name: NewRelic
   hosts: inventory-web,!v2
   vars:

--- a/ansible/roles/software/ckan/catalog/www/defaults/main.yml
+++ b/ansible/roles/software/ckan/catalog/www/defaults/main.yml
@@ -1,2 +1,6 @@
 ---
 datagov_team_email: team@example.com
+
+catalog_log_dir: /var/log/ckan
+catalog_ckan_error_log: "{{ catalog_log_dir }}/ckan.error.log"
+catalog_ckan_access_log: "{{ catalog_log_dir }}/ckan.access.log"

--- a/ansible/roles/software/ckan/catalog/www/molecule/default/tests/test_default.py
+++ b/ansible/roles/software/ckan/catalog/www/molecule/default/tests/test_default.py
@@ -22,3 +22,4 @@ def test_apache2_site(host):
     assert f.user == 'root'
     assert f.group == 'www-data'
     assert f.mode == 0o644
+    assert f.contains('ErrorLog /var/log/ckan/ckan.error.log')

--- a/ansible/roles/software/ckan/catalog/www/tasks/main.yml
+++ b/ansible/roles/software/ckan/catalog/www/tasks/main.yml
@@ -1,4 +1,12 @@
 ---
+- name: Create log directory
+  file: >-
+    path={{ catalog_log_dir }}
+    state=directory
+    owner=root
+    group=www-data
+    mode=0755
+
 - name: Copy all needed files
   action: copy src={{item}} dest=/{{item}} mode=0644 owner=root group=www-data
   with_items:

--- a/ansible/roles/software/ckan/catalog/www/templates/etc/apache2/sites-enabled/ckan.default.conf.j2
+++ b/ansible/roles/software/ckan/catalog/www/templates/etc/apache2/sites-enabled/ckan.default.conf.j2
@@ -32,12 +32,8 @@ SSLEngine on
       Require all granted
     </Directory>
 
-    ErrorLog /var/log/apache2/ckan.error.log
-
-    LogFormat "\"%{True-Client-IP}i\" %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" trueip
-    SetEnvIf True-Client-IP "^.*\..*\..*\..*" akamai
-    CustomLog /var/log/apache2/ckan.custom.log combined env=!akamai
-    CustomLog /var/log/apache2/ckan.custom.log trueip env=akamai
+    ErrorLog {{ catalog_ckan_error_log }}
+    CustomLog {{ catalog_ckan_access_log }} combined
 
     # fix Cross-Frame Scripting (XFS) vulnerability
     Header set X-Frame-Options "SAMEORIGIN"

--- a/ansible/roles/software/ckan/catalog/www/templates/etc/apache2/sites-enabled/ckan.readonly.conf.j2
+++ b/ansible/roles/software/ckan/catalog/www/templates/etc/apache2/sites-enabled/ckan.readonly.conf.j2
@@ -31,12 +31,8 @@ SSLEngine on
       Require all granted
     </Directory>
 
-    ErrorLog /var/log/apache2/ckan.error.log
-
-    LogFormat "\"%{True-Client-IP}i\" %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" trueip
-    SetEnvIf True-Client-IP "^.*\..*\..*\..*" akamai
-    CustomLog /var/log/apache2/ckan.custom.log combined env=!akamai
-    CustomLog /var/log/apache2/ckan.custom.log trueip env=akamai
+    ErrorLog {{ catalog_ckan_error_log }}
+    CustomLog {{ catalog_ckan_access_log }} combined
 
     # fix Cross-Frame Scripting (XFS) vulnerability
     Header set X-Frame-Options "SAMEORIGIN"

--- a/ansible/roles/software/ckan/catalog/www/templates/etc/apache2/sites-enabled/ckan.writable.conf.j2
+++ b/ansible/roles/software/ckan/catalog/www/templates/etc/apache2/sites-enabled/ckan.writable.conf.j2
@@ -32,12 +32,8 @@ SSLEngine on
       Require all granted
     </Directory>
 
-    ErrorLog /var/log/apache2/ckan.error.log
-
-    LogFormat "\"%{True-Client-IP}i\" %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" trueip
-    SetEnvIf True-Client-IP "^.*\..*\..*\..*" akamai
-    CustomLog /var/log/apache2/ckan.custom.log combined env=!akamai
-    CustomLog /var/log/apache2/ckan.custom.log trueip env=akamai
+    ErrorLog {{ catalog_ckan_error_log }}
+    CustomLog {{ catalog_ckan_access_log }} combined
 
     # fix Cross-Frame Scripting (XFS) vulnerability
     Header set X-Frame-Options "SAMEORIGIN"

--- a/ansible/roles/software/ckan/inventory/defaults/main.yml
+++ b/ansible/roles/software/ckan/inventory/defaults/main.yml
@@ -5,6 +5,12 @@ ckan_virtual_env: "{{virtual_env}}"
 datapusher_virtual_env: /usr/lib/datapusher
 app_type: inventory
 
+inventory_log_dir: /var/log/inventory
+inventory_ckan_error_log: "{{ inventory_log_dir }}/ckan.error.log"
+inventory_ckan_access_log: "{{ inventory_log_dir }}/ckan.access.log"
+inventory_datapusher_error_log: "{{ inventory_log_dir }}/datapusher.error.log"
+inventory_datapusher_access_log: "{{ inventory_log_dir }}/datapusher.access.log"
+
 # packages to install ckan app
 ckan_pkgs:
   - {

--- a/ansible/roles/software/ckan/inventory/molecule/default/prepare.yml
+++ b/ansible/roles/software/ckan/inventory/molecule/default/prepare.yml
@@ -5,6 +5,7 @@
     - name: ensure system packages are installed
       apt:
         name:
+          - apache2
           - git
           - libbz2-dev
           - libpq-dev
@@ -68,12 +69,3 @@
         owner: root
         group: www-data
         mode: 0750
-
-    - name: create fake apache2 config dir
-      file:
-        path: /etc/apache2/sites-enabled
-        state: directory
-        owner: root
-        group: www-data
-        mode: 0750
-

--- a/ansible/roles/software/ckan/inventory/molecule/default/tests/test_default.py
+++ b/ansible/roles/software/ckan/inventory/molecule/default/tests/test_default.py
@@ -12,3 +12,21 @@ def test_hosts_file(host):
     assert f.exists
     assert f.user == 'root'
     assert f.group == 'root'
+
+
+def test_apache2_sites(host):
+    ckan = host.file('/etc/apache2/sites-enabled/ckan.conf')
+    datapusher = host.file('/etc/apache2/sites-enabled/datapusher.conf')
+
+    assert ckan.exists
+    assert ckan.user == 'root'
+    assert ckan.group == 'www-data'
+    assert ckan.mode == 0o640
+    assert ckan.contains('ErrorLog /var/log/inventory/ckan.error.log')
+
+    assert datapusher.exists
+    assert datapusher.user == 'root'
+    assert datapusher.group == 'www-data'
+    assert datapusher.mode == 0o640
+    assert datapusher.contains(
+        'ErrorLog /var/log/inventory/datapusher.error.log')

--- a/ansible/roles/software/ckan/inventory/tasks/install.yml
+++ b/ansible/roles/software/ckan/inventory/tasks/install.yml
@@ -6,6 +6,9 @@
     - swig
     - xmlsec1
 
+- name: Create log directory
+  file: path={{ inventory_log_dir }} state=directory owner=root group=www-data mode=0750
+
 - name: Remove old rollback code
   file: path="{{ project_source_rollback_path }}" state=absent
 
@@ -56,14 +59,15 @@
     - etc/ckan/who.ini
     - etc/ckan/apache.wsgi
     - etc/ckan/datapusher.wsgi
-    - etc/apache2/sites-enabled/ckan.conf
-    - etc/apache2/sites-enabled/datapusher.conf
 
 - name: Configure production.ini
-  template: src=templates/{{ item }} dest=/{{ item }} owner=root group=www-data mode=0640
+  template: src={{ item }} dest=/{{ item }} owner=root group=www-data mode=0640
   with_items:
     - etc/ckan/production.ini
     - etc/ckan/datapusher_settings.py
+    - etc/apache2/sites-enabled/ckan.conf
+    - etc/apache2/sites-enabled/datapusher.conf
+
 
 - include: additional-tasks.yml
   virtualenv: "{{ project_source_new_code_path }}"

--- a/ansible/roles/software/ckan/inventory/tasks/main.yml
+++ b/ansible/roles/software/ckan/inventory/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
-- include_tasks: install.yml
+- import_tasks: install.yml
 
-- include_tasks: db-setup.yml
+- import_tasks: db-setup.yml
   tags: [ 'never', 'db-setup' ]
-- include_tasks: db-init.yml
+- import_tasks: db-init.yml
   tags: [ 'never', 'db-init' ]

--- a/ansible/roles/software/ckan/inventory/templates/etc/apache2/sites-enabled/ckan.conf
+++ b/ansible/roles/software/ckan/inventory/templates/etc/apache2/sites-enabled/ckan.conf
@@ -36,12 +36,8 @@ WSGISocketPrefix /var/run/wsgi
 
     # Header add Content-Security-Policy "default-src 'self'"
 
-    ErrorLog /var/log/apache2/ckan.error.log
-
-    LogFormat "\"%{True-Client-IP}i\" %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" trueip
-    SetEnvIf True-Client-IP "^.*\..*\..*\..*" akamai
-    CustomLog /var/log/apache2/ckan.custom.log combined env=!akamai
-    CustomLog /var/log/apache2/ckan.custom.log trueip env=akamai
+    ErrorLog {{ inventory_ckan_error_log }}
+    CustomLog {{ inventory_ckan_access_log }} combined
 
     <Directory /etc/ckan>
       Options All
@@ -75,4 +71,3 @@ WSGISocketPrefix /var/run/wsgi
     RewriteRule ^ /user/login [R]
 
 </VirtualHost>
-

--- a/ansible/roles/software/ckan/inventory/templates/etc/apache2/sites-enabled/datapusher.conf
+++ b/ansible/roles/software/ckan/inventory/templates/etc/apache2/sites-enabled/datapusher.conf
@@ -21,7 +21,7 @@ WSGISocketPrefix /var/run/wsgi
       Require all granted
     </Directory>
 
-    ErrorLog /var/log/apache2/datapusher.error.log
-    CustomLog /var/log/apache2/datapusher.custom.log combined
+    ErrorLog {{ inventory_datapusher_error_log }}
+    CustomLog {{ inventory_ckan_access_log }} combined
 
 </VirtualHost>


### PR DESCRIPTION
Fixes https://github.com/GSA/datagov-deploy/issues/949

Moves the CKAN logs to their own app directory. Adds an aggressive logrotate configuration for catalog.