### PR TITLE
[inventory] remove entry from hosts

### DIFF
--- a/ansible/roles/software/ckan/inventory/tasks/install.yml
+++ b/ansible/roles/software/ckan/inventory/tasks/install.yml
@@ -86,6 +86,6 @@
     - molecule-notest
 
 - name: point site_url in /etc/hosts to localhost
-  action: lineinfile dest=/etc/hosts line="127.0.0.1 {{ ckan_site_domain | regex_replace('https?\://','') }}"
+  action: lineinfile dest=/etc/hosts line="127.0.0.1 {{ ckan_site_domain | regex_replace('https?\://','') }}" state=absent
   tags:
     - molecule-notest # Device or resource busy ranaming temp file


### PR DESCRIPTION
Remove the aliasing of inventory service to localhost. This seems like an
optimization that skips the extra routing, caching, WAF but is unexpected when
debugging. I'd rather remove it for now.