### PR TITLE
[inventory] remove datapusher https hack

### DIFF
--- a/ansible/roles/software/ckan/inventory/tasks/additional-tasks.yml
+++ b/ansible/roles/software/ckan/inventory/tasks/additional-tasks.yml
@@ -31,13 +31,6 @@
     replace: 'application/x-www-form-urlencoded'
   notify: restart apache2
 
-- name: "Datapusher https to http temp fix (local https is unreachable now)"
-  replace:
-    dest: /usr/lib/datapusher/lib/python2.7/site-packages/ckanserviceprovider/web.py
-    regexp: 'result_url,'
-    replace: "result_url.replace('https://','http://'),"
-  notify: restart apache2
-
 - name: "Remove compiled web.pyc"
   file:
     path: /usr/lib/datapusher/lib/python2.7/site-packages/ckanserviceprovider/web.pyc


### PR DESCRIPTION
I believe this was introduced because of the host certificates, which didn't
work without some extra CA configuration on staging (and maybe production).
After removing https://github.com/GSA/datagov-deploy/pull/965, datapusher might
just push to the service-level name which would have a proper https
configuration.

Either way, this hack should go as it's causes confusion about how datapusher
works with inventory.