### PR TITLE
Lower pod-dashboard max_remote_size to 127Mb from 500Mb

### DIFF
--- a/ansible/roles/software/dashboard/dashboard-deploy/templates/config/config.php
+++ b/ansible/roles/software/dashboard/dashboard-deploy/templates/config/config.php
@@ -20,7 +20,7 @@ $config['s3_prefix'] = '{{ s3_prefix }}';
 
 $config['import_active'] = true;
 $config['show_all_offices'] = false;
-$config['max_remote_size'] = 500000000;
+$config['max_remote_size'] = (int)(127 * 1E6); // 127MB
 
 $config['google_analytics_id'] = ''; // UA-xxxxxxx-xx
 $config['google_analytics_domain'] = ''; // domain.com


### PR DESCRIPTION
`get_file_contents` fails with max_size 500MB (and 256Mb) but seems OK w/ 127MB