### PR TITLE
[hotfix] [catalog] fix newrelic app name

### DIFF
--- a/ansible/catalog-web.yml
+++ b/ansible/catalog-web.yml
@@ -76,7 +76,7 @@
 - name: NewRelic
   hosts: catalog-admin,!v2
   vars:
-    newrelic_app_name: catalog-admin,!v2
+    newrelic_app_name: catalog-admin
   roles:
     - monitoring/newrelic/python-agent-ansible
 


### PR DESCRIPTION
Accidentally changed the newrelic application name, roll it back.