### PR TITLE
[catalog] reduce log output

### DIFF
--- a/ansible/roles/software/ckan/catalog/ckan-app/templates/etc/ckan/production.ini.j2
+++ b/ansible/roles/software/ckan/catalog/ckan-app/templates/etc/ckan/production.ini.j2
@@ -270,7 +270,7 @@ keys = console
 keys = generic
 
 [logger_root]
-level = INFO
+level = WARNING
 handlers = console
 
 [logger_ckan]


### PR DESCRIPTION
Getting too much logging from repoze.who. This reduces the log level on the root logger.