### PR TITLE
[postfix] update sender_canonical_maps

### DIFF
--- a/ansible/inventories/production/group_vars/all/vars.yml
+++ b/ansible/inventories/production/group_vars/all/vars.yml
@@ -196,7 +196,7 @@ postfix_aliases:
   - user: root
     alias: "{{ datagov_team_email }}"
 postfix_sender_canonical_maps:
-  - sender: root
+  - sender: "@{{ ansible_fqdn }}"
     rewrite: no-reply+{{ ansible_fqdn }}@data.gov
 
 

--- a/ansible/inventories/staging/group_vars/all/vars.yml
+++ b/ansible/inventories/staging/group_vars/all/vars.yml
@@ -181,7 +181,7 @@ postfix_aliases:
   - user: root
     alias: "{{ datagov_team_email }}"
 postfix_sender_canonical_maps:
-  - sender: root
+  - sender: "@{{ ansible_fqdn }}"
     rewrite: no-reply+{{ ansible_fqdn }}@data.gov
 
 


### PR DESCRIPTION
This wasn't implemented correctly, should be a catch-all @example.com entry so
that any outgoing mail is re-mapped.