### PR TITLE
[hotfix] Allow the CKAN status API for Inventory

### DIFF
--- a/ansible/roles/software/ckan/inventory/files/etc/apache2/sites-enabled/ckan.conf
+++ b/ansible/roles/software/ckan/inventory/files/etc/apache2/sites-enabled/ckan.conf
@@ -69,6 +69,7 @@ WSGISocketPrefix /var/run/wsgi
     RewriteCond %{REQUEST_URI} !^/api/3/action/datastore_create
     RewriteCond %{REQUEST_URI} !^/api/action/member_list
     RewriteCond %{REQUEST_URI} !^/api/3/action/member_list
+    RewriteCond %{REQUEST_URI} !^/api/action/status_show
     RewriteCond %{REQUEST_URI} !^/api/i18n/en
     RewriteCond %{REQUEST_URI} !^/api/1/util/snippet/[^/]
 


### PR DESCRIPTION
This updates the apache2 config to allow requests to `/api/action/status_show` which can be used as a health check for Inventory.