### PR TITLE
[hotfix] for inventory to bionic transition

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -78,6 +78,7 @@
         # signed certs which should be valid.
         # https://github.com/GSA/datagov-deploy/issues/900
         validate_certs: false
+      when: datagov_in_service | default(true)
 
 
 - name: logrotate configuration

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -103,6 +103,8 @@
     newrelic_app_name: inventory
   roles:
     - monitoring/newrelic/python-agent-ansible
+  tags:
+    - newrelic
 
 
 - name: Service-level smoke tests

--- a/ansible/roles/monitoring/newrelic/python-agent-ansible/handlers/main.yml
+++ b/ansible/roles/monitoring/newrelic/python-agent-ansible/handlers/main.yml
@@ -1,2 +1,4 @@
+---
 - name: restart apache
   service: name=apache2 state=restarted
+  when: datagov_in_service | default(true)

--- a/ansible/roles/software/ckan/saml2/handlers/main.yml
+++ b/ansible/roles/software/ckan/saml2/handlers/main.yml
@@ -1,3 +1,4 @@
 ---
 - name: reload apache2
   service: name=apache2 state=reloaded
+  when: datagov_in_service | default(true)


### PR DESCRIPTION
`datagov_in_service` was implemented in the inventory role, but because of how the other roles interact, the out of service instances would have apache2 restarted, hence breaking the intention and putting the Trusty hosts back online.

This added some confusion to debugging why bionic wasn't working because, in fact, it might have been the Trusty hosts misbehaving.