### PR TITLE
[hotfix] typo in ckan qa worker crontab

### DIFF
--- a/ansible/roles/software/ckan/catalog/harvest/files/etc/cron.d/ckan_qa_worker
+++ b/ansible/roles/software/ckan/catalog/harvest/files/etc/cron.d/ckan_qa_worker
@@ -1,1 +1,1 @@
-*/5 * * * * root supervosorctl start celery-mem-check > /dev/null
+*/5 * * * * root supervisorctl start celery-mem-check > /dev/null


### PR DESCRIPTION
Fixes typo in the crontab.