### PR TITLE
Fix typo in cronjob name

### DIFF
--- a/ansible/roles/software/ckan/catalog/harvest/files/etc/cron.d/ckan_qa_worker
+++ b/ansible/roles/software/ckan/catalog/harvest/files/etc/cron.d/ckan_qa_worker
@@ -1,1 +1,1 @@
-*/5 * * * * root supervosorctl start celery-mem-check > /dev/null
+*/5 * * * * root supervisorctl start celery-mem-check > /dev/null


### PR DESCRIPTION
I noticed mail mentioning this job failing and this is the only place I was able to find it, so I'm hoping that fixing the typo here will help.