### PR TITLE
Update onboarding/offboarding checklist

### DIFF
--- a/.github/ISSUE_TEMPLATE/offboard-team-member.md
+++ b/.github/ISSUE_TEMPLATE/offboard-team-member.md
@@ -7,16 +7,18 @@ These tasks are performed by an Admin unless noted as an action for the outgoing
 
 - [ ] Team member should move all Data.gov related documents to team drives
 - [ ] Team member should document any work in progress and schedule a hand-off for any remaining tasks
-- [ ] Remove user from Data.gov GitHub teams
+- [ ] Remove team member from Data.gov GitHub teams
   - [ ] [data-gov-admins](https://github.com/orgs/GSA/teams/data-gov-admin/members)
   - [ ] [data-gov-support](https://github.com/orgs/GSA/teams/data-gov-support/members)
   - [ ] [data-gov-ckan-multi-partners](https://github.com/orgs/GSA/teams/data-gov-ckan-multi-partners)
 - [ ] Remove access from [GSA GitHub org](https://github.com/GSA/GitHub-Administration/blob/master/README.md#removing-access-to-the-gsa-organization) (if leaving GSA)
+- [ ] Remove team member from AWS OPP account
 - [ ] Remove team member from [AWS sandbox access](https://github.com/GSA/datagov-infrastructure-live/tree/master/iam#new-users)
 - [ ] Remove team member from [jumpbox operators](https://github.com/GSA/datagov-deploy/blob/develop/ansible/group_vars/all/vault.yml)
 - [ ] Remove team member from Data.gov email lists
   - [ ] [Data.gov support list](https://groups.google.com/a/gsa.gov/forum/#!forum/datagov)
   - [ ] [Data.gov team list](https://groups.google.com/a/gsa.gov/forum/#!forum/datagovhelp)
+- [ ] Remove team member from [Data.gov calendar](https://calendar.google.com/calendar/r/settings/calendar/Z3NhLmdvdl9zcjZ0NG52YjRhOTNjNnNzdHRxYXAzbjZtMEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t) and events
 - [ ] Remove team member from Uptrends via [email](https://docs.google.com/spreadsheets/d/1Z9Zpr1mpx-65i_fH2VTbVofPtidpLZs5cnkO0Jz53Vc/edit#gid=0)
 - [ ] Remove team member from [New Relic](https://newrelic.com)
 - [ ] Remove team member from [Docker Hub](https://cloud.docker.com/orgs/datagov/teams)

--- a/.github/ISSUE_TEMPLATE/onboard-team-member.md
+++ b/.github/ISSUE_TEMPLATE/onboard-team-member.md
@@ -11,7 +11,7 @@ Below are the tasks that will drive the onboarding process.
 ### Tasks for admin or onboarding buddy
 
 - [ ] Add team member to [TTS Slack](https://handbook.18f.gov/slack/#tts-staff) and #datagov-devsecops
-- [ ] Invite team member to calendar events
+- [ ] Invite team member to [Data.gov calendar](https://calendar.google.com/calendar/r/settings/calendar/Z3NhLmdvdl9zcjZ0NG52YjRhOTNjNnNzdHRxYXAzbjZtMEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t) and events
   - Daily sync
   - Sprint planning
   - Retro
@@ -28,14 +28,10 @@ Below are the tasks that will drive the onboarding process.
 - [ ] Request TTS Bug Bounty access [#bug-bounty-partners](https://gsa-tts.slack.com/messages/C5JQCD9PH)
 - [ ] Share Ansible vault keys with team member
 - [ ] Grant access to AWS OPP account
-- [ ] Add team member to monthly CKAN US working group calls
 - [ ] Add team member to Uptrends via [email](https://docs.google.com/spreadsheets/d/1Z9Zpr1mpx-65i_fH2VTbVofPtidpLZs5cnkO0Jz53Vc/edit#gid=0)
 - [ ] Add team member to [New Relic](https://newrelic.com)
 - [ ] Add team member to [Docker Hub](https://cloud.docker.com/orgs/datagov/teams)
-- [ ] Introduce team member at next TTS-Solutions meeting
-- [ ] Introduce new team member to OMB team
-- [ ] Introduce new team member to the Federal Geospatial Data Community
-- [ ] Introduce new team member to government Open Data community at monthly meeting
+
 
 For new Project Management Office team members, follow these additional steps:
 


### PR DESCRIPTION
Adds link to the calendar, removes introductions, which are tied to the calendar events anyway.