### PR TITLE
Enable audit report on a few hosts

### DIFF
--- a/ansible/inventories/production/group_vars/all/vars.yml
+++ b/ansible/inventories/production/group_vars/all/vars.yml
@@ -18,7 +18,7 @@ catalog_pycsw_db_user: "{{ vault_catalog_pycsw_db_user }}"
 
 
 # common
-common_audit_report_enabled: true
+common_audit_report_enabled: false
 common_filebeat_logstash_output: "{{ vault_common_filebeat_logstash_output }}"
 common_filebeat_config:
   filebeat.config.modules:

--- a/ansible/inventories/production/host_vars/catalog-web1p.prod-ocsit.bsp.gsa.gov/vars.yml
+++ b/ansible/inventories/production/host_vars/catalog-web1p.prod-ocsit.bsp.gsa.gov/vars.yml
@@ -14,3 +14,6 @@ catalog_pycsw_db_pass: "{{ vault_catalog_pycsw_db_pass }}"
 
 # other
 catalog_ckan_solr_host: datagov-solr1p.prod-ocsit.bsp.gsa.gov
+
+
+common_audit_report_enabled: true

--- a/ansible/inventories/production/host_vars/datagov-jump2p.prod-ocsit.bsp.gsa.gov/vars.yml
+++ b/ansible/inventories/production/host_vars/datagov-jump2p.prod-ocsit.bsp.gsa.gov/vars.yml
@@ -1,0 +1,2 @@
+---
+common_audit_report_enabled: true

--- a/ansible/inventories/staging/group_vars/all/vars.yml
+++ b/ansible/inventories/staging/group_vars/all/vars.yml
@@ -20,7 +20,7 @@ catalog_pycsw_db_user: "{{ vault_catalog_pycsw_db_user }}"
 
 
 # common
-common_audit_report_enabled: true
+common_audit_report_enabled: false
 common_filebeat_logstash_output: "{{ vault_common_filebeat_logstash_output }}"
 common_filebeat_config:
   filebeat.config.modules:

--- a/ansible/inventories/staging/host_vars/catalogpub-web1d.dev-ocsit.bsp.gsa.gov/vars.yml
+++ b/ansible/inventories/staging/host_vars/catalogpub-web1d.dev-ocsit.bsp.gsa.gov/vars.yml
@@ -19,3 +19,5 @@ catalog_ckan_db_user: "{{ vault_catalog_ckan_db_user }}"
 
 # other
 catalog_ckan_solr_host: datagov-solrm1d.dev-ocsit.bsp.gsa.gov
+
+common_audit_report_enabled: true

--- a/ansible/inventories/staging/host_vars/datagov-jump2d.dev-ocsit.bsp.gsa.gov/vars.yml
+++ b/ansible/inventories/staging/host_vars/datagov-jump2d.dev-ocsit.bsp.gsa.gov/vars.yml
@@ -1,0 +1,2 @@
+---
+common_audit_report_enabled: true


### PR DESCRIPTION
Instead of enabling the audit report across all hosts and generating ~60 emails
per week, let's start with a handful of hosts and tune the reporting. Once we
have a reasonable sized report we can roll it out to all hosts.