### PR TITLE
[hotfix] fix datapusher

### DIFF
--- a/ansible/inventories/staging/group_vars/all/vars.yml
+++ b/ansible/inventories/staging/group_vars/all/vars.yml
@@ -116,6 +116,7 @@ default_tls_host_certificate: |-
 jumpbox_operators: "{{ datagov_operators_production }}"
 
 
+inventory_app_environment: staging
 inventory_ckan_service_url: https://inventory-datagov.dev-ocsit.bsp.gsa.gov
 inventory_ckan_solr_host: datagov-solrm1d.dev-ocsit.bsp.gsa.gov
 inventory_ckan_solr_port: "8983"

--- a/ansible/roles/software/ckan/inventory/defaults/main.yml
+++ b/ansible/roles/software/ckan/inventory/defaults/main.yml
@@ -7,6 +7,7 @@ ckan_virtual_env: "{{virtual_env}}"
 datapusher_virtual_env: /usr/lib/datapusher
 app_type: inventory
 
+inventory_app_environment: production
 inventory_log_dir: /var/log/inventory
 inventory_ckan_error_log: "{{ inventory_log_dir }}/ckan.error.log"
 inventory_ckan_access_log: "{{ inventory_log_dir }}/ckan.access.log"
@@ -49,11 +50,10 @@ ckan_pkgs:
     }
 
 datapusher_pkgs:
-  - {
-      name: "datapusher",
-      repo: "https://github.com/GSA/datapusher",
-      requirements: "requirements.txt"
-    }
+  - name: datapusher
+    repo: https://github.com/GSA/datapusher
+    requirements: requirements.txt
+
 
 # provide some default values to be overwritten later by group vars and host vars...
 project_source_rollback_path: /usr/lib/ckan-rollback

--- a/ansible/roles/software/ckan/inventory/tasks/install.yml
+++ b/ansible/roles/software/ckan/inventory/tasks/install.yml
@@ -54,13 +54,13 @@
   with_items:
     - etc/ckan/who.ini
     - etc/ckan/apache.wsgi
-    - etc/ckan/datapusher.wsgi
   notify: restart apache2
 
 - name: Configure production.ini
   template: src={{ item }} dest=/{{ item }} owner=root group=www-data mode=0640
   with_items:
     - etc/ckan/production.ini
+    - etc/ckan/datapusher.wsgi
     - etc/ckan/datapusher_settings.py
     - etc/apache2/sites-enabled/ckan.conf
     - etc/apache2/sites-enabled/datapusher.conf

--- a/ansible/roles/software/ckan/inventory/templates/etc/apache2/sites-enabled/ckan.conf
+++ b/ansible/roles/software/ckan/inventory/templates/etc/apache2/sites-enabled/ckan.conf
@@ -15,9 +15,9 @@ WSGISocketPrefix /var/run/wsgi
     WSGIPassAuthorization On
 
     # Deploy as a daemon (avoids conflicts between CKAN instances)
-    WSGIDaemonProcess demo display-name=demo processes=2 threads=15
+    WSGIDaemonProcess ckan display-name=ckan processes=2 threads=15
 
-    WSGIProcessGroup demo
+    WSGIProcessGroup ckan
 
     # fix Cross-Frame Scripting (XFS) vulnerability
     Header add X-Frame-Options "SAMEORIGIN"
@@ -51,6 +51,9 @@ WSGISocketPrefix /var/run/wsgi
 
     # redirect to login page except resource and api
     RewriteCond %{HTTP_REFERER} !^https://.*\.max\.gov [NC]
+    # allow requests with an API key to hit CKAN
+    RewriteCond %{HTTP:X-CKAN-API-KEY} !^$
+    RewriteCond %{HTTP:Authorization} !^$
     RewriteCond %{HTTP:Cookie} !.*auth_tkt=.*
     RewriteCond %{REMOTE_ADDR} !^127\.0\.0\.1
     RewriteCond %{REQUEST_URI} !^/user/

--- a/ansible/roles/software/ckan/inventory/templates/etc/apache2/sites-enabled/datapusher.conf
+++ b/ansible/roles/software/ckan/inventory/templates/etc/apache2/sites-enabled/datapusher.conf
@@ -11,7 +11,7 @@ WSGISocketPrefix /var/run/wsgi
     WSGIPassAuthorization On
 
     # Deploy as a daemon (avoids conflicts between CKAN instances)
-    WSGIDaemonProcess datapusher display-name=demo processes=1 threads=15
+    WSGIDaemonProcess datapusher display-name=datapusher processes=1 threads=15
 
     WSGIProcessGroup datapusher
 

--- a/ansible/roles/software/ckan/inventory/templates/etc/ckan/datapusher.wsgi
+++ b/ansible/roles/software/ckan/inventory/templates/etc/ckan/datapusher.wsgi
@@ -6,11 +6,13 @@ activate_this = os.path.join('/usr/lib/datapusher/bin/activate_this.py')
 execfile(activate_this, dict(__file__=activate_this))
 
 import ckanserviceprovider.web as web
+{% if inventory_app_environment == 'staging' %}
+# Use GSA's CA for python requests in staging
+os.environ.setdefault('REQUESTS_CA_BUNDLE', '/etc/ssl/certs/ca-certificates.crt')
+{% endif %}
 os.environ['JOB_CONFIG'] = '/etc/ckan/datapusher_settings.py'
 web.init()
 
 import datapusher.jobs as jobs
 
 application = web.app
-
-


### PR DESCRIPTION
https://github.com/GSA/datagov-deploy/issues/1185

Datapusher is unable to push data into datastore on Inventory, seeing error
"cannot decode JSON".

- Allow requests with API key to hit CKAN
- Use GSA's CA bundle in staging
- Update datapusher/ckan process names for easier debugging

https://github.com/GSA/datapusher/pull/2 is also part of the fix.