### PR TITLE
[catalog] fix tracking

### DIFF
--- a/ansible/catalog-web.yml
+++ b/ansible/catalog-web.yml
@@ -30,7 +30,6 @@
       when: datagov_enable_postgresql_role is defined
 
 
-
 - name: Catalog web stack
   hosts: catalog-web
   serial: 1
@@ -66,9 +65,15 @@
       tags:
         - saml2
 
+
+- name: Fix tracking
+  hosts: catalog-web,!catalog-admin
+  roles:
     - role: software/ckan/fix-ckan-tracking
+      when: catalog_tracking_fix_enabled
       tags:
         - frontend
+
 
 - name: NewRelic
   hosts: catalog-web,!catalog-admin
@@ -76,6 +81,7 @@
     newrelic_app_name: catalog
   roles:
     - monitoring/newrelic/python-agent-ansible
+
 
 - name: NewRelic
   hosts: catalog-admin

--- a/ansible/inventories/production/group_vars/all/vars.yml
+++ b/ansible/inventories/production/group_vars/all/vars.yml
@@ -13,6 +13,7 @@ catalog_pycsw_db_host: "{{ vault_catalog_pycsw_db_host }}"
 catalog_pycsw_db_name: "{{ vault_catalog_pycsw_db_name }}"
 catalog_pycsw_db_pass: "{{ vault_catalog_pycsw_db_pass }}"
 catalog_pycsw_db_user: "{{ vault_catalog_pycsw_db_user }}"
+catalog_tracking_fix_enabled: true
 
 
 # common

--- a/ansible/roles/software/ckan/fix-ckan-tracking/tasks/main.yml
+++ b/ansible/roles/software/ckan/fix-ckan-tracking/tasks/main.yml
@@ -1,17 +1,14 @@
 ---
-
-# spaghetti js fix
-- name: set env
-  set_fact:
-    current_env: "{{ inventory_dir | basename }}"
-
-- name: copy spaghetti to /tmp folder
+# TODO move this to catalog application
+# The catalog-web hosts are configured with a read-only database connection so
+# they cannot write the tracking information. when the /_tracking endpoint is
+# hit.  This JS bundle changes the tracking url to the admin-catalog.data.gov
+# (hard-coded) so visits to catalog.data.gov will still be tracked.
+- name: copy tracking fix to /tmp folder
   copy:
     src: js.tgz
     dest: /tmp/js.tgz
-  when: (inventory_hostname != "catalogpub-web1p.prod-ocsit.bsp.gsa.gov") and (current_env == "production")
 
-- name: make plate of spaghetti
+- name: install tracking fix
   shell: cd /tmp && tar -xf /tmp/js.tgz -C /
-  when: (inventory_hostname != "catalogpub-web1p.prod-ocsit.bsp.gsa.gov") and (current_env == "production")
   notify: reload apache2


### PR DESCRIPTION
Removes current_env, which only works when --inventory is specified in
a specific way. Best to use an explicit variable instead.