### PR TITLE
[wordpress] add labs.data.gov to host whitelist

### DIFF
--- a/ansible/inventories/production/group_vars/all/vars.yml
+++ b/ansible/inventories/production/group_vars/all/vars.yml
@@ -240,5 +240,5 @@ ci_deploy_version: master
 
 # wordpress
 # hostname needed for smoke test, IP address needed for ALB health check
-wordpress_nginx_server_name: www.data.gov data.gov wp-bsp.data.gov $hostname {{ ansible_default_ipv4.address }}
+wordpress_nginx_server_name: www.data.gov data.gov wp-bsp.data.gov labs.data.gov $hostname {{ ansible_default_ipv4.address }}
 wordpress_service_url: https://www.data.gov


### PR DESCRIPTION
Fixes https://github.com/GSA/datagov-deploy/issues/1205