### PR TITLE
[dashboard] mute cron

### DIFF
--- a/ansible/roles/software/dashboard/dashboard-deploy/tasks/main.yml
+++ b/ansible/roles/software/dashboard/dashboard-deploy/tasks/main.yml
@@ -74,7 +74,7 @@
     user: root
     minute: 15
     hour: 4
-    job: supervisorctl start dashboard-cfo-act-download
+    job: supervisorctl start dashboard-cfo-act-download > /dev/null
     disabled: "{{ not crons_enabled }}"
     state: present
   become: yes
@@ -86,7 +86,7 @@
     user: root
     minute: 30
     hour: 4
-    job: supervisorctl start dashboard-cfo-act-full-scan
+    job: supervisorctl start dashboard-cfo-act-full-scan > /dev/null
     disabled: "{{ not crons_enabled }}"
     state: present
   become: yes


### PR DESCRIPTION
Make sure to produce no output on a successful cron run and avoid sending
emails with non-actionable "started" messages.