### PR TITLE
setuptools fix for python 2

### DIFF
--- a/ansible/roles/software/ckan/catalog/ckan-app/tasks/main.yml
+++ b/ansible/roles/software/ckan/catalog/ckan-app/tasks/main.yml
@@ -46,7 +46,7 @@
   pip:
     name:
       - pip>=19.3.0
-      - setuptools>=44.0.0
+      - setuptools>=44.0.0,<45.0.0  # setuptools 45+ requires python 3.5, keep pinned below, but still modern version
     virtualenv: '{{ project_source_new_code_path }}'
     virtualenv_python: "{{ catalog_ckan_python_home }}/bin/python"
     umask: "0022"

--- a/ansible/roles/software/ckan/inventory/tasks/install.yml
+++ b/ansible/roles/software/ckan/inventory/tasks/install.yml
@@ -44,7 +44,7 @@
   pip:
     name:
       - pip>=19.3.0
-      - setuptools>=44.0.0
+      - setuptools>=44.0.0,<45.0.0  # setuptools 45+ requires python 3.5, keep pinned below, but still modern version
     virtualenv: '{{ project_source_new_code_path }}'
     virtualenv_python: "{{ inventory_ckan_python_home }}/bin/python"
     umask: "0022"


### PR DESCRIPTION
setuptools 45 was just released and only supports >=python 3.5. Pin to a modern version that works for python 2.