### PR TITLE
[catalog] increase number of CKAN workers

### DIFF
--- a/ansible/inventories/production/group_vars/all/vars.yml
+++ b/ansible/inventories/production/group_vars/all/vars.yml
@@ -11,6 +11,7 @@ catalog_ckan_qa_update_process_count: 5
 catalog_ckan_service_url: https://catalog.data.gov
 catalog_ckan_solr_port: "8983"
 catalog_ckan_solr_host: datagov-solr1p.prod-ocsit.bsp.gsa.gov
+catalog_ckan_wsgi_processes: 6
 catalog_pycsw_db_host: "{{ vault_catalog_pycsw_db_host }}"
 catalog_pycsw_db_name: "{{ vault_catalog_pycsw_db_name }}"
 catalog_pycsw_db_pass: "{{ vault_catalog_pycsw_db_pass }}"

--- a/ansible/roles/software/ckan/catalog/www/defaults/main.yml
+++ b/ansible/roles/software/ckan/catalog/www/defaults/main.yml
@@ -4,3 +4,4 @@ datagov_team_email: team@example.com
 catalog_log_dir: /var/log/ckan
 catalog_ckan_error_log: "{{ catalog_log_dir }}/ckan.error.log"
 catalog_ckan_access_log: "{{ catalog_log_dir }}/ckan.access.log"
+catalog_ckan_wsgi_processes: 2

--- a/ansible/roles/software/ckan/catalog/www/templates/etc/apache2/sites-enabled/ckan.default.conf.j2
+++ b/ansible/roles/software/ckan/catalog/www/templates/etc/apache2/sites-enabled/ckan.default.conf.j2
@@ -22,7 +22,7 @@ SSLEngine on
     WSGIPassAuthorization On
 
     # Deploy as a daemon (avoids conflicts between CKAN instances).
-    WSGIDaemonProcess ckan display-name=ckan processes=2 threads=15
+    WSGIDaemonProcess ckan display-name=ckan processes={{ catalog_ckan_wsgi_processes }} threads=15
 
     WSGIProcessGroup ckan
 

--- a/ansible/roles/software/ckan/catalog/www/templates/etc/apache2/sites-enabled/ckan.readonly.conf.j2
+++ b/ansible/roles/software/ckan/catalog/www/templates/etc/apache2/sites-enabled/ckan.readonly.conf.j2
@@ -21,7 +21,7 @@ SSLEngine on
     WSGIPassAuthorization On
 
     # Deploy as a daemon (avoids conflicts between CKAN instances).
-    WSGIDaemonProcess ckan display-name=ckan processes=2 threads=15
+    WSGIDaemonProcess ckan display-name=ckan processes={{ catalog_ckan_wsgi_processes }} threads=15
 
     WSGIProcessGroup ckan
 

--- a/ansible/roles/software/ckan/catalog/www/templates/etc/apache2/sites-enabled/ckan.writable.conf.j2
+++ b/ansible/roles/software/ckan/catalog/www/templates/etc/apache2/sites-enabled/ckan.writable.conf.j2
@@ -22,7 +22,7 @@ SSLEngine on
     WSGIPassAuthorization On
 
     # Deploy as a daemon (avoids conflicts between CKAN instances).
-    WSGIDaemonProcess ckan display-name=ckan processes=2 threads=15
+    WSGIDaemonProcess ckan display-name=ckan processes={{ catalog_ckan_wsgi_processes }} threads=15
 
     WSGIProcessGroup ckan
 


### PR DESCRIPTION
In response to the outage on 2020-01-27, we think the catalog hosts have more
capacity to respond to requests. The theory is that Apache2 is queuing up
requests because the CKAN workers are all busy. There is plenty of CPU and
memory available on these hosts to accommodate additional CKAN processes.

https://gsa-tts.slack.com/archives/C2N85536E/p1580151221030200