### PR TITLE
Use upstream beats role

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Once you're SSH'd into the jumpbox, follow these steps for deploy.
 1. Run the playbook from the ansible directory.
 
        $ cd ansible
-       $ pipenv run ansible-playbook site.yml --skip-tags filebeat
+       $ pipenv run ansible-playbook site.yml
 
    _Note: we skip filebeat on deploys due to a version lock (https://github.com/GSA/datagov-deploy-common/issues/24)._
 

--- a/ansible/roles/vendor/requirements.yml
+++ b/ansible/roles/vendor/requirements.yml
@@ -42,9 +42,6 @@
 - name: gsa.ansible-os-ubuntu-16
   src: https://github.com/GSA/ansible-os-ubuntu-16
   version: 1.0.4
-- name: gsa.ansible-role-beats
-  src: https://github.com/GSA/ansible-role-beats
-  version: master
 - name: gsa.datagov-deploy-ci
   src: https://github.com/GSA/datagov-deploy-ci
   version: master
@@ -59,7 +56,7 @@
   version: v1.3.0
 - name: gsa.datagov-deploy-common
   src: https://github.com/GSA/datagov-deploy-common
-  version: v2.5.1
+  version: v3.0.0
 - name: gsa.datagov-deploy-jenkins
   src: https://github.com/GSA/datagov-deploy-jenkins
   version: master
@@ -86,6 +83,8 @@
   version: master
 - name: jnv.unattended-upgrades
   version: v1.8.0
+- name: jobscore.beats
+  version: v1.0.0
 - name: newrelic.newrelic-infra
   version: 0.7.0
 - name: nickhammond.logrotate


### PR DESCRIPTION
Bumps gsa.datagov-deploy-common which uses the upstream beats role. This also
fixes the issue requiring us to use `--skip-tags filebeat` since the upstream
role handles this correctly.