### PR TITLE
Increase PHP memory to help crawls succeed

### DIFF
--- a/ansible/inventories/production/group_vars/all/vars.yml
+++ b/ansible/inventories/production/group_vars/all/vars.yml
@@ -53,7 +53,7 @@ crm_service_url: https://labs.data.gov/crm
 # hostname needed for smoke test, IP address needed for ALB health check
 dashboard_nginx_server_name: labs.data.gov labs-bsp.data.gov dashboard-bsp.data.gov $hostname {{ ansible_default_ipv4.address }}
 dashboard_service_url: https://labs.data.gov/dashboard
-
+php_cli_memory_limit: 3192M
 
 # data.gov-wide variables
 datagov_environment: production


### PR DESCRIPTION
Related to https://github.com/GSA/datagov-deploy/issues/1193

The expansion of the set of offices being crawled makes the crawl itself more memory-hungry and subject to being killed for using too much memory. The production hosts have more memory, and this change increases the headroom for the crawl to succeed.