### PR TITLE
Replace beats role with upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,7 @@ Once you're SSH'd into the jumpbox, follow these steps for deploy.
 1. Run the playbook from the ansible directory.
 
        $ cd ansible
-       $ pipenv run ansible-playbook site.yml --skip-tags filebeat
-
-   _Note: we skip filebeat on deploys due to a version lock (see [GSA/datagov-deploy-common #24](https://github.com/GSA/datagov-deploy-common/issues/24))._
+       $ pipenv run ansible-playbook site.yml
    
    For sandbox environment, use `--skip-tags database` due to buggy gsa.datagov-deploy-postgresql role (see [#1336](https://github.com/GSA/datagov-deploy/issues/1336)).
 

--- a/ansible/roles/vendor/requirements.yml
+++ b/ansible/roles/vendor/requirements.yml
@@ -53,7 +53,7 @@
   version: v1.3.0
 - name: gsa.datagov-deploy-common
   src: https://github.com/GSA/datagov-deploy-common
-  version: v2.5.1
+  version: v3.0.0
 - name: gsa.datagov-deploy-jenkins
   src: https://github.com/GSA/datagov-deploy-jenkins
   version: master

--- a/ansible/roles/vendor/requirements.yml
+++ b/ansible/roles/vendor/requirements.yml
@@ -42,9 +42,6 @@
 - name: gsa.ansible-os-ubuntu-16
   src: https://github.com/GSA/ansible-os-ubuntu-16
   version: 1.0.4
-- name: gsa.ansible-role-beats
-  src: https://github.com/GSA/ansible-role-beats
-  version: master
 - name: gsa.datagov-deploy-dashboard
   src: https://github.com/GSA/datagov-deploy-dashboard
   version: v1.0.2
@@ -83,6 +80,8 @@
   version: master
 - name: jnv.unattended-upgrades
   version: v1.8.0
+- name: jobscore.beats
+  version: v1.0.0
 - name: newrelic.newrelic-infra
   version: 0.7.0
 - name: nickhammond.logrotate


### PR DESCRIPTION
gsa.datagov-deploy-common was already updated with this change, but we forgot to
make it in our requirements.yml.