### PR TITLE
[hotfix][inventory] enable bionic hosts

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -65,4 +65,9 @@ ignore:
         reason: >-
           Remote hosts are trusted, only allowing access to operators.
         expires: 2020-06-17T06:00:00.000Z
+  SNYK-PYTHON-ANSIBLE-561048:
+    - '*':
+        reason: >-
+          Fix not yet released https://github.com/ansible/ansible/pull/68431
+        expires: 2020-03-31T06:00:00.000Z
 patch: {}

--- a/ansible/inventories/production/group_vars/inventory-web-v1/vars.yml
+++ b/ansible/inventories/production/group_vars/inventory-web-v1/vars.yml
@@ -1,2 +1,2 @@
 ---
-datagov_in_service: true
+datagov_in_service: false

--- a/ansible/inventories/production/group_vars/inventory-web-v2/vars.yml
+++ b/ansible/inventories/production/group_vars/inventory-web-v2/vars.yml
@@ -1,2 +1,2 @@
 ---
-datagov_in_service: false
+datagov_in_service: true

--- a/ansible/inventories/staging/group_vars/inventory-web-v1/vars.yml
+++ b/ansible/inventories/staging/group_vars/inventory-web-v1/vars.yml
@@ -1,2 +1,2 @@
 ---
-datagov_in_service: true
+datagov_in_service: false

--- a/ansible/inventories/staging/group_vars/inventory-web-v2/vars.yml
+++ b/ansible/inventories/staging/group_vars/inventory-web-v2/vars.yml
@@ -1,2 +1,2 @@
 ---
-datagov_in_service: false
+datagov_in_service: true


### PR DESCRIPTION
Part of https://github.com/GSA/datagov-deploy/issues/717

Enable bionic (v2) hosts and disable trusty (v1) hosts.

- [x] deploy and monitor on staging
- [ ] deploy and monitor on production