### PR TITLE
Ignore host keys on Jenkins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ ARG APP_GID=1000
 # Configure pipenv to install to the project directory
 ENV PIPENV_VENV_IN_PROJECT=1
 
+# Ignore host keys
+ENV ANSIBLE_HOST_KEY_CHECKING=False
+
 # Install build dependencies
 RUN apk add \
   gcc \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
       }
       steps {
         ansiColor('xterm') {
-          sh 'docker run --rm -v $SSH_KEY_FILE:$SSH_KEY_FILE -v $ANSIBLE_VAULT_FILE:$ANSIBLE_VAULT_FILE -u $(id -u) datagov/datagov-deploy:latest pipenv run ansible-playbook --key-file=$SSH_KEY_FILE --vault-password-file=$ANSIBLE_VAULT_FILE --inventory inventories/ci site.yml'
+          sh 'docker run --rm -v $SSH_KEY_FILE:$SSH_KEY_FILE -v $ANSIBLE_VAULT_FILE:$ANSIBLE_VAULT_FILE -u $(id -u) datagov/datagov-deploy:latest pipenv run ansible-playbook --key-file=$SSH_KEY_FILE --vault-password-file=$ANSIBLE_VAULT_FILE --inventory inventories/ci site.yml --skip-tags database'
         }
       }
     }


### PR DESCRIPTION
I was testing out the Jenkins deploy in prep for review and realized it wasn't
working, getting stuck waiting for input and a tty for SSH host key checking.

We don't have a great way to keep host keys up to date in Jenkins. Ignore the
host keys to keep things simple when deploying with the container.