### PR TITLE
[trendmicro] use explicit policy ids

### DIFF
--- a/ansible/inventories/mgmt/group_vars/jumpbox/vars.yml
+++ b/ansible/inventories/mgmt/group_vars/jumpbox/vars.yml
@@ -1,0 +1,4 @@
+---
+# Work-around for https://github.com/GSA/datagov-deploy/issues/1397
+# Disable trendmicro until a policy id is set.
+trendmicro_enabled: false

--- a/ansible/inventories/production/group_vars/catalog-harvester/vars.yml
+++ b/ansible/inventories/production/group_vars/catalog-harvester/vars.yml
@@ -40,3 +40,5 @@ ckan_instance_uuid: "{{ vault_ckan_instance_secret }}"
 # token_dat for Google Analytics
 token_dat: "{{ vault_token_dat }}"
 
+# Trendmicro firewall policy
+trendmicro_policy_id: "{{ trendmicro_policy_id_app }}"

--- a/ansible/inventories/production/group_vars/catalog-web/vars.yml
+++ b/ansible/inventories/production/group_vars/catalog-web/vars.yml
@@ -28,3 +28,6 @@ ckan_instance_uuid: "{{ vault_ckan_instance_secret }}"
 
 # token_dat for Google Analytics
 token_dat: "{{ vault_token_dat }}"
+
+# Trendmicro firewall policy
+trendmicro_policy_id: "{{ trendmicro_policy_id_web }}"

--- a/ansible/inventories/production/group_vars/dashboard-web/vars.yml
+++ b/ansible/inventories/production/group_vars/dashboard-web/vars.yml
@@ -24,3 +24,6 @@ env_content_protocol: https
 # MAX SAML
 saml_sp_private_key: "{{ vault_saml_private_key }}"
 saml_admin_pass: "{{ vault_saml_admin_pass }}"
+
+# Trendmicro firewall policy
+trendmicro_policy_id: "{{ trendmicro_policy_id_web }}"

--- a/ansible/inventories/production/group_vars/inventory-web/vars.yml
+++ b/ansible/inventories/production/group_vars/inventory-web/vars.yml
@@ -35,3 +35,6 @@ saml2_site_url: "{{ vault_saml2_site_url }}"
 who_ini_secret: "{{ vault_who_ini_secret }}"
 ckan_instance_secret: "{{ vault_ckan_instance_secret }}"
 ckan_instance_uuid: "{{ vault_ckan_instance_secret }}"
+
+# Trendmicro firewall policy
+trendmicro_policy_id: "{{ trendmicro_policy_id_web }}"

--- a/ansible/inventories/production/group_vars/jumpbox/vars.yml
+++ b/ansible/inventories/production/group_vars/jumpbox/vars.yml
@@ -1,0 +1,4 @@
+---
+# Work-around for https://github.com/GSA/datagov-deploy/issues/1397
+# Disable trendmicro until a policy id is set.
+trendmicro_enabled: false

--- a/ansible/inventories/production/group_vars/solr/vars.yml
+++ b/ansible/inventories/production/group_vars/solr/vars.yml
@@ -5,3 +5,6 @@ datagov_service: solr
 # master. Once the solr cluster is loaded, this can be hoisted up to
 # inventory/group_vars/all level
 solr_master_server: datagov-solrm1p.prod-ocsit.bsp.gsa.gov
+
+# Trendmicro firewall policy
+trendmicro_policy_id: "{{ trendmicro_policy_id_app }}"

--- a/ansible/inventories/production/group_vars/wordpress-web/vars.yml
+++ b/ansible/inventories/production/group_vars/wordpress-web/vars.yml
@@ -31,3 +31,5 @@ secure_auth_salt: "{{ vault_secure_auth_salt }}"
 logged_in_salt: "{{ vault_logged_in_salt }}"
 nonce_salt: "{{ vault_nonce_salt }}"
 
+# Trendmicro firewall policy
+trendmicro_policy_id: "{{ trendmicro_policy_id_web }}"

--- a/ansible/inventories/staging/group_vars/catalog-harvester/vars.yml
+++ b/ansible/inventories/staging/group_vars/catalog-harvester/vars.yml
@@ -40,3 +40,5 @@ ckan_instance_uuid: "{{ vault_ckan_instance_secret }}"
 # token_dat for Google Analytics
 token_dat: "{{ vault_token_dat }}"
 
+# Trendmicro firewall policy
+trendmicro_policy_id: "{{ trendmicro_policy_id_app }}"

--- a/ansible/inventories/staging/group_vars/catalog-web/vars.yml
+++ b/ansible/inventories/staging/group_vars/catalog-web/vars.yml
@@ -28,3 +28,5 @@ ckan_instance_uuid: "{{ vault_ckan_instance_secret }}"
 # token_dat for Google Analytics
 token_dat : "{{ vault_token_dat }}"
 
+# Trendmicro firewall policy
+trendmicro_policy_id: "{{ trendmicro_policy_id_web }}"

--- a/ansible/inventories/staging/group_vars/dashboard-web/vars.yml
+++ b/ansible/inventories/staging/group_vars/dashboard-web/vars.yml
@@ -25,3 +25,6 @@ env_content_protocol: https
 # MAX SAML
 saml_sp_private_key: "{{ vault_saml_private_key }}"
 saml_admin_pass: "{{ vault_saml_admin_pass }}"
+
+# Trendmicro firewall policy
+trendmicro_policy_id: "{{ trendmicro_policy_id_web }}"

--- a/ansible/inventories/staging/group_vars/inventory-web/vars.yml
+++ b/ansible/inventories/staging/group_vars/inventory-web/vars.yml
@@ -35,3 +35,6 @@ saml2_site_url: "{{ vault_saml2_site_url }}"
 who_ini_secret: "{{ vault_who_ini_secret }}"
 ckan_instance_secret: "{{ vault_ckan_instance_secret }}"
 ckan_instance_uuid: "{{ vault_ckan_instance_secret }}"
+
+# Trendmicro firewall policy
+trendmicro_policy_id: "{{ trendmicro_policy_id_web }}"

--- a/ansible/inventories/staging/group_vars/jumpbox/vars.yml
+++ b/ansible/inventories/staging/group_vars/jumpbox/vars.yml
@@ -1,0 +1,4 @@
+---
+# Work-around for https://github.com/GSA/datagov-deploy/issues/1397
+# Disable trendmicro until a policy id is set.
+trendmicro_enabled: false

--- a/ansible/inventories/staging/group_vars/solr/vars.yml
+++ b/ansible/inventories/staging/group_vars/solr/vars.yml
@@ -5,3 +5,6 @@ datagov_service: solr
 # master. Once the solr cluster is loaded, this can be hoisted up to
 # inventory/group_vars/all level
 solr_master_server: datagov-solrm1d.dev-ocsit.bsp.gsa.gov
+
+# Trendmicro firewall policy
+trendmicro_policy_id: "{{ trendmicro_policy_id_app }}"

--- a/ansible/inventories/staging/group_vars/wordpress-web/vars.yml
+++ b/ansible/inventories/staging/group_vars/wordpress-web/vars.yml
@@ -31,3 +31,5 @@ secure_auth_salt: "{{ vault_secure_auth_salt }}"
 logged_in_salt: "{{ vault_logged_in_salt }}"
 nonce_salt: "{{ vault_nonce_salt }}"
 
+# Trendmicro firewall policy
+trendmicro_policy_id: "{{ trendmicro_policy_id_web }}"

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -52,7 +52,7 @@
   version: v1.3.0
 - name: gsa.datagov-deploy-common
   src: https://github.com/GSA/datagov-deploy-common
-  version: v3.0.0
+  version: v4.0.0
 - name: gsa.datagov-deploy-jenkins
   src: https://github.com/GSA/datagov-deploy-jenkins
   version: master


### PR DESCRIPTION
https://github.com/GSA/datagov-deploy/issues/1389

The policy id corresponds roughly to the "Tier" described by our [BSP Firewall Rules](https://docs.google.com/spreadsheets/d/1-fYQmlY4M3_VBA2GF4aXKmVd7y0Y1TcmVBR5zMjxD4E/edit#gid=1191460452). I say "roughly" because I'm not sure if the spreadsheet is really up to date. It's not a source of truth.