### PR TITLE
Fix writing .retry files in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,5 +26,7 @@ RUN pip install pipenv && pipenv sync
 RUN pipenv run make vendor
 
 RUN addgroup -S -g $APP_GID app && adduser -S -G app -u $APP_UID app
+RUN chown app:app /app/ansible
+
 USER app
 WORKDIR /app/ansible


### PR DESCRIPTION
app user doesn't have write permissions to the ansible directory, preventing it
from writing .retry files. This doesn't really matter, because we're not using
the .retry files and if we're trying to write the .retry file, the play has
already failed. This is more just to prevent the error message which is
distracting.