### PR TITLE
fix inventory logrotate

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -92,7 +92,7 @@
       logrotate_scripts:
         - name: inventory
           paths:
-            - /var/log/inventory/*
+            - /var/log/inventory/*.log
           options:
             - compress
             - copytruncate


### PR DESCRIPTION
stop logrotate generating million of files by  gzipping files that has already been gzipped.
https://github.com/GSA/datagov-deploy/issues/1183