### PR TITLE
Bump datagov-deploy-wordpress

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -73,7 +73,7 @@
   version: v1.0.0
 - name: gsa.datagov-deploy-wordpress
   src: https://github.com/GSA/datagov-deploy-wordpress.git
-  version: v1.0.3
+  version: v1.0.4
 - name: gsa.elastalert
   src: https://github.com/GSA/ansible-elastalert
   version: master


### PR DESCRIPTION
Pulls in fix for the subdomain redirects https://github.com/GSA/datagov-deploy/issues/1105