### PR TITLE
Update o-and-m.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/o-and-m.md
+++ b/.github/ISSUE_TEMPLATE/o-and-m.md
@@ -1,20 +1,17 @@
-As part of day-to-day operation of Data.gov, there are many [Operation and Maintenance (O&M) responsibilities](https://github.com/GSA/datagov-deploy/wiki/Operation-and-Maintenance-Responsibilities). Instead of having the entire team watching notifications and risking some notifications slipping through the cracks, we have created an [O&M Triage role](https://github.com/GSA/datagov-deploy/wiki/Operation-and-Maintenance-Responsibilities#om-triage-rotation). One person on the team is assigned the Triage role which rotates each week. 
+As part of day-to-day operation of Data.gov, there are many [Operation and Maintenance (O&M) responsibilities](https://github.com/GSA/datagov-deploy/wiki/Operation-and-Maintenance-Responsibilities). Instead of having the entire team watching notifications and risking some notifications slipping through the cracks, we have created an [O&M Triage role](https://github.com/GSA/datagov-deploy/wiki/Operation-and-Maintenance-Responsibilities#om-triage-rotation). One person on the team is assigned the Triage role which rotates each week.
 
-In addition to performing triage, here are the things that the person assigned should be focusing on:
+Each day, you should start your triage by looking through the notification channels for anything **urgent** that came in after hours that might need immediate attention:
 
-## Ad-hoc/daily
-- [ ] [Responding to technical support issues (ad-hoc email)](https://github.com/GSA/datagov-deploy/wiki/Operation-and-Maintenance-Responsibilities#responding-to-technical-support-issues-ad-hoc-email)
-- [ ] [Vulnerable dependency notifications (daily email reports)](https://github.com/GSA/datagov-deploy/wiki/Operation-and-Maintenance-Responsibilities#vulnerable-dependency-notifications-daily-email-reports)
-- [ ] [Harvest job report (daily email report)](https://github.com/GSA/datagov-deploy/wiki/Operation-and-Maintenance-Responsibilities#harvest-job-report-daily-email-report)
-- [ ] [Bug bounty report (ad-hoc email)](https://github.com/GSA/datagov-deploy/wiki/Operation-and-Maintenance-Responsibilities#bug-bounty-report-ad-hoc-email)
-- [ ] [Automated dependency updates (ad-hoc GitHub PRs)](https://github.com/GSA/datagov-deploy/wiki/Operation-and-Maintenance-Responsibilities#automated-dependency-updates-ad-hoc-github-prs)
-- [ ] [Triaging system alerts (ad-hoc email)](https://github.com/GSA/datagov-deploy/wiki/Operation-and-Maintenance-Responsibilities#triaging-system-alerts-ad-hoc-email)
-- [ ] [Host notifications (ad-hoc email)](https://github.com/GSA/datagov-deploy/wiki/Operation-and-Maintenance-Responsibilities#host-notifications-ad-hoc-email)
-- [ ] [Reboot notifications (ad-hoc email)](https://github.com/GSA/datagov-deploy/wiki/Operation-and-Maintenance-Responsibilities#reboot-notifications-ad-hoc-email)
-- [ ] [WordPress broken links report (daily email report)](https://github.com/GSA/datagov-deploy/wiki/Operation-and-Maintenance-Responsibilities#wordpress-broken-links-report-daily-email-report)
-- [ ] [Dedupe report (daily email report)](https://github.com/GSA/datagov-deploy/wiki/Operation-and-Maintenance-Responsibilities#dedupe-report-daily-email-report)
-- [ ] [Update notifications (slack #datagov-notifications)](https://github.com/GSA/datagov-deploy/wiki/Operation-and-Maintenance-Responsibilities#update-notifications-slack-datagov-notifications)
+- [#datagov-alerts](https://gsa-tts.slack.com/archives/C4RGAM1Q8) may contain critical host alerts
+- [Bug bounty report (ad-hoc email)](https://github.com/GSA/datagov-deploy/wiki/Operation-and-Maintenance-Responsibilities#bug-bounty-report-ad-hoc-email)
+- [Vulnerable dependency notifications (daily email reports)](https://github.com/GSA/datagov-deploy/wiki/Operation-and-Maintenance-Responsibilities#vulnerable-dependency-notifications-daily-email-reports)
 
-## Weekly
 
-- [ ] [AU-6 Log auditing](https://github.com/GSA/datagov-deploy/wiki/Operation-and-Maintenance-Responsibilities#au-6-log-auditing)
+## Acceptance criteria
+
+You are responsible for all [O&M responsibilities](https://github.com/GSA/datagov-deploy/wiki/Operation-and-Maintenance-Responsibilities) this week. We've highlighted a few so they're not forgotten.
+
+- [ ] [Audit log updated](https://docs.google.com/spreadsheets/d/1z6lqmyNxC7s5MiTt9f6vT41IS2DLLJl4HwEqXvvft40/edit) for [AU-6 Log auditing](https://github.com/GSA/datagov-deploy/wiki/Operation-and-Maintenance-Responsibilities#au-6-log-auditing) (**Friday**).
+- [ ] Any [New Relic alerts](https://alerts.newrelic.com/accounts/1601367/incidents) have been addressed or GH issues created.
+- [ ] Weekly [Nessus scan](https://github.com/GSA/datagov-deploy/wiki/Operation-and-Maintenance-Responsibilities#nessus-host-scan-report-from-isso) has been traiged.
+- [ ] If received, the monthly [Netsparker scan](https://github.com/GSA/datagov-deploy/wiki/Operation-and-Maintenance-Responsibilities#netsparker-compliance-scan-report-from-isso) has been traiged.


### PR DESCRIPTION
From retro, we identified that critical issues coming in after hours weren't getting looked at as the first thing in the morning.

- Highlight the "start of day" tasks
- Remove the daily/ad-hoc tasks to avoid "clutter" and duplication.
- Emphasize that *all* O&M responsibilities are part of this work
- Provide AC so that important tasks don't get overlooked.