### PR TITLE
Add dbm support required by pysaml2 repoze plugin

### DIFF
--- a/ansible/roles/software/ckan/common/vars/bionic.yml
+++ b/ansible/roles/software/ckan/common/vars/bionic.yml
@@ -2,10 +2,10 @@
 ckan_os_packages:
   - git
   - libbz2-dev
+  - libgdbm-dev
   - libgeos-dev
   - libpq-dev
   - libxml2-dev
   - libxslt1-dev
   - python-dev
   - virtualenv
-  - libgdbm-dev

--- a/ansible/roles/software/ckan/common/vars/bionic.yml
+++ b/ansible/roles/software/ckan/common/vars/bionic.yml
@@ -8,3 +8,4 @@ ckan_os_packages:
   - libxslt1-dev
   - python-dev
   - virtualenv
+  - libgdbm-dev


### PR DESCRIPTION
Add required lib for pysaml2.  

Related to https://github.com/GSA/datagov-deploy/pull/1541