### PR TITLE
[catalog] fix redirect loop on sandbox

### DIFF
--- a/ansible/inventories/bionic/group_vars/all/vars.yml
+++ b/ansible/inventories/bionic/group_vars/all/vars.yml
@@ -1,6 +1,5 @@
 ---
 # catalog
-catalog_ckan_allow_login_routes: true
 catalog_ckan_app_version: bionic
 catalog_ckan_db_host: "{{ catalog_postgresql_login_host }}"
 catalog_ckan_db_name: ckan

--- a/ansible/inventories/ci/group_vars/all/vars.yml
+++ b/ansible/inventories/ci/group_vars/all/vars.yml
@@ -1,6 +1,5 @@
 ---
 # catalog
-catalog_ckan_allow_login_routes: true
 catalog_ckan_app_version: master
 catalog_ckan_db_host: "{{ catalog_postgresql_login_host }}"
 catalog_ckan_db_name: ckan

--- a/ansible/inventories/production/group_vars/all/vars.yml
+++ b/ansible/inventories/production/group_vars/all/vars.yml
@@ -9,6 +9,7 @@ catalog_ckan_db_user: "{{ vault_catalog_ckan_db_user }}"
 catalog_ckan_harvest_fetch_process_count: 6
 catalog_ckan_plugins_additional: [saml2]
 catalog_ckan_qa_update_process_count: 5
+catalog_ckan_readwrite_configuration: readonly
 catalog_ckan_saml2_enabled: true
 catalog_ckan_service_url: https://catalog.data.gov
 catalog_ckan_solr_port: "8983"

--- a/ansible/inventories/production/group_vars/catalog-admin/vars.yml
+++ b/ansible/inventories/production/group_vars/catalog-admin/vars.yml
@@ -1,2 +1,2 @@
 ---
-catalog_ckan_allow_login_routes: true
+catalog_ckan_readwrite_configuration: readwrite

--- a/ansible/inventories/sandbox/group_vars/all/vars.yml
+++ b/ansible/inventories/sandbox/group_vars/all/vars.yml
@@ -1,6 +1,5 @@
 ---
 # catalog
-catalog_ckan_allow_login_routes: true
 catalog_ckan_app_version: master
 catalog_ckan_db_host: "{{ catalog_postgresql_login_host }}"
 catalog_ckan_db_name: ckan

--- a/ansible/inventories/staging/group_vars/all/vars.yml
+++ b/ansible/inventories/staging/group_vars/all/vars.yml
@@ -10,6 +10,7 @@ catalog_ckan_db_user: "{{ vault_catalog_ckan_db_user }}"
 catalog_ckan_harvest_fetch_process_count: 6
 catalog_ckan_plugins_additional: [saml2]
 catalog_ckan_qa_update_process_count: 5
+catalog_ckan_readwrite_configuration: readonly
 catalog_ckan_saml2_enabled: true
 catalog_ckan_service_url: https://catalog-datagov.dev-ocsit.bsp.gsa.gov
 catalog_ckan_solr_host: datagov-solr1d.dev-ocsit.bsp.gsa.gov

--- a/ansible/inventories/staging/group_vars/catalog-admin/vars.yml
+++ b/ansible/inventories/staging/group_vars/catalog-admin/vars.yml
@@ -1,2 +1,2 @@
 ---
-catalog_ckan_allow_login_routes: true
+catalog_ckan_readwrite_configuration: readwrite

--- a/ansible/roles/software/ckan/catalog/ckan-app/defaults/main.yml
+++ b/ansible/roles/software/ckan/catalog/ckan-app/defaults/main.yml
@@ -3,7 +3,7 @@ datagov_team_email: team@example.com
 
 catalog_app_type: web  # either web or worker
 catalog_ckan_access_log: "{{ catalog_log_dir }}/ckan.access.log"
-catalog_ckan_allow_login_routes: false
+catalog_ckan_readwrite_configuration: default  # One of [default, readwrite, readonly]
 catalog_ckan_app_version: master
 catalog_ckan_error_log: "{{ catalog_log_dir }}/ckan.error.log"
 catalog_ckan_harvest_fetch_process_count: 2

--- a/ansible/roles/software/ckan/catalog/ckan-app/molecule/readwrite/Dockerfile.j2
+++ b/ansible/roles/software/ckan/catalog/ckan-app/molecule/readwrite/Dockerfile.j2
@@ -1,0 +1,14 @@
+# Molecule managed
+
+{% if item.registry is defined %}
+FROM {{ item.registry.url }}/{{ item.image }}
+{% else %}
+FROM {{ item.image }}
+{% endif %}
+
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates && apt-get clean; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python2-dnf bash && dnf clean all; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml && zypper clean -a; \
+    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \
+    elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python sudo bash ca-certificates && xbps-remove -O; fi

--- a/ansible/roles/software/ckan/catalog/ckan-app/molecule/readwrite/molecule.yml
+++ b/ansible/roles/software/ckan/catalog/ckan-app/molecule/readwrite/molecule.yml
@@ -1,0 +1,62 @@
+---
+dependency:
+  name: galaxy
+  options:
+    role-file: molecule/shared/requirements.yml
+driver:
+  name: docker
+lint:
+  name: yamllint
+  enabled: false
+platforms:
+  - name: ckan-catalog-app-trusty
+    image: ubuntu:trusty
+    # start-stop-daemon doesn't detect tomcat is running in docker and `service
+    # start/stop` fails. SYS_PTRACE is needed.
+    # https://stackoverflow.com/questions/29683231/tomcat7-fail-to-start-inside-ubuntu-docker-container/29686963#29686963
+    capabilities:
+      - SYS_PTRACE
+  - name: ckan-catalog-app-bionic
+    image: ubuntu:bionic
+    # start-stop-daemon doesn't detect tomcat is running in docker and `service
+    # start/stop` fails. SYS_PTRACE is needed.
+    # https://stackoverflow.com/questions/29683231/tomcat7-fail-to-start-inside-ubuntu-docker-container/29686963#29686963
+    capabilities:
+      - SYS_PTRACE
+    groups:
+      - v2
+provisioner:
+  name: ansible
+  inventory:
+    group_vars:
+      all:
+        catalog_ckan_who_ini_secret: e45cfed3-40f1-41c0-8e92-77eda7ddd9f3
+        # https://github.com/DavidWittman/ansible-redis/blob/21b0b6f9030275a2586baf591f322ce3348b2b2d/tasks/install.yml#L9
+        redis_travis_ci: true
+      v2:
+        app_repo_branch: bionic
+  lint:
+    name: ansible-lint
+  playbooks:
+    prepare: ../shared/prepare.yml
+scenario:
+  name: readwrite
+  # Disable idempotence check
+  # davidwittman.redis is not idempotent
+  # https://github.com/DavidWittman/ansible-redis/pull/202
+  test_sequence:
+    - lint
+    - destroy
+    - dependency
+    - syntax
+    - create
+    - prepare
+    - converge
+    # - idempotence
+    - side_effect
+    - verify
+    - destroy
+verifier:
+  name: testinfra
+  lint:
+    name: flake8

--- a/ansible/roles/software/ckan/catalog/ckan-app/molecule/readwrite/playbook.yml
+++ b/ansible/roles/software/ckan/catalog/ckan-app/molecule/readwrite/playbook.yml
@@ -1,0 +1,7 @@
+---
+- name: Converge
+  hosts: all
+  roles:
+    - role: ckan-app
+      catalog_ckan_readwrite_configuration: readwrite
+      url_readonly: https://readonly.ckan

--- a/ansible/roles/software/ckan/catalog/ckan-app/templates/etc_apache2_sites-enabled_ckan.conf.j2
+++ b/ansible/roles/software/ckan/catalog/ckan-app/templates/etc_apache2_sites-enabled_ckan.conf.j2
@@ -50,7 +50,8 @@ SSLEngine on
     # Header set Content-Security-Policy "default-src 'self'"
 
     RewriteEngine On
-{% if catalog_ckan_allow_login_routes %}
+{% if catalog_ckan_readwrite_configuration == 'readwrite' %}
+    {# Allow login, redirect any unauthed requests to the readonly site #}
     RewriteCond %{REQUEST_URI}     !^/api/action/status_show
     RewriteCond %{REQUEST_URI}     !^/user/(login|logged_in|_logout|logged_out|logged_out_redirect)
     RewriteCond %{REQUEST_URI}     !^/login_generic
@@ -58,7 +59,7 @@ SSLEngine on
     RewriteCond %{HTTP_REFERER}    !{{saml2_idp_entry}} [NC]
     RewriteCond %{HTTP_COOKIE}     !auth_tkt
     RewriteRule ^(.*)$ {{ url_readonly }}$1 [R,L]
-{% else %}
+{% elif catalog_ckan_readwrite_configuration == 'readonly' %}
     RewriteRule   "^(/en)?/user/login"  "{{ url_writable }}/user/login" [R,L]
     RewriteRule   "^(/en)?/user/_logout"  "{{ url_writable }}/user/_logout"  [R,L]
     RewriteRule   "^(/en)?/user/logged_in"  "{{ url_writable }}/user/logged_in"  [R,L]


### PR DESCRIPTION
https://github.com/GSA/datagov-deploy/issues/1611

Allow a "default" configuration with no redirects so that standalone ckan is
still supported. Production and staging designate readwrite and readonly hosts.

