### PR TITLE
Don't require sudo for localhost delegation

### DIFF
--- a/ansible/catalog-web.yml
+++ b/ansible/catalog-web.yml
@@ -96,3 +96,4 @@
         validate_certs: false
       run_once: true
       delegate_to: localhost
+      become: false

--- a/ansible/dashboard-web.yml
+++ b/ansible/dashboard-web.yml
@@ -65,6 +65,7 @@
         validate_certs: false
       run_once: true
       delegate_to: localhost
+      become: false
       register: result
       retries: 3
       delay: 20

--- a/ansible/datagov-web.yml
+++ b/ansible/datagov-web.yml
@@ -96,6 +96,7 @@
         validate_certs: false
       run_once: true
       delegate_to: localhost
+      become: false
       register: result
       retries: 3
       delay: 10

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -29,6 +29,7 @@
       delay: 10
       register: result
       until: not result.failed
+      become: false
       when: datagov_in_service | default(true)
 
     - name: assert app is up
@@ -93,6 +94,7 @@
           Cookie: auth_tkt=1
       run_once: true
       delegate_to: localhost
+      become: false
       retries: 3
       delay: 10
       register: result

--- a/ansible/pycsw.yml
+++ b/ansible/pycsw.yml
@@ -95,6 +95,7 @@
       register: csw_collection
       run_once: true
       delegate_to: localhost
+      become: false
 
     - name: assert csw-collection response has title
       fail:
@@ -102,6 +103,7 @@
       when: csw_collection.content is not search("<ows:Title>CSW interface for catalog.data.gov</ows:Title>")
       run_once: true
       delegate_to: localhost
+      become: false
 
     - name: assert csw-all is up
       uri:
@@ -116,6 +118,7 @@
       register: csw_all
       run_once: true
       delegate_to: localhost
+      become: false
 
     - name: assert csw-all response has title
       fail:
@@ -123,3 +126,4 @@
       when: csw_all.content is not search("<ows:Title>CSW interface for catalog.data.gov</ows:Title>")
       run_once: true
       delegate_to: localhost
+      become: false


### PR DESCRIPTION
https://github.com/GSA/datagov-ckan-multi/issues/287

When running from within the Jenkins container, we see "sudo not found" error
when running smoke tests. Avoid `become` when delegating to the localhost so we
don't need unnecessary requirements on the Ansible host (like sudo).