### PR TITLE
[cd] remove quiet period

### DIFF
--- a/ansible/templates/jenkins_config_sandbox.yml.j2
+++ b/ansible/templates/jenkins_config_sandbox.yml.j2
@@ -90,7 +90,6 @@ jobs:
           } } }
           disableConcurrentBuilds()
           githubProjectUrl('{{ job.github_project_url | default("https://github.com/GSA/datagov-deploy") }}')
-          quietPeriod(120)
         }
         definition {
           cpsScm {


### PR DESCRIPTION
Use the default global 5 second quiet period. Since our builds are not triggered
in bursts, there's not need for a two minute quiet period.