### PR TITLE
[cd] always notify

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,7 @@ pipeline {
     }
   }
   post {
-    failure {
+    always {
       step([$class: 'GitHubIssueNotifier', issueAppend: true])
     }
   }


### PR DESCRIPTION
By running the notifier on _every_ build, the failed build issue will be closed
when the build starts passing.