### PR TITLE
naming the harvest-report cron

### DIFF
--- a/ansible/roles/software/ckan/catalog/ckan-app/tasks/worker.yml
+++ b/ansible/roles/software/ckan/catalog/ckan-app/tasks/worker.yml
@@ -61,6 +61,7 @@
 
 - name: schedule harvest-report cron
   cron: >-
+    name="harvest-report"
     cron_file=harvest-report
     job=/usr/local/bin/harvest-report.sh
     disabled={{ not (datagov_in_service | default(true)) }}


### PR DESCRIPTION
give it a name to avoid duplicate entries. 