### PR TITLE
[inventory] fix permissions on ckan dirs

### DIFF
--- a/ansible/roles/software/ckan/common/tasks/main.yml
+++ b/ansible/roles/software/ckan/common/tasks/main.yml
@@ -6,6 +6,12 @@
   apt: name={{ item }} state=present
   with_items: "{{ ckan_os_packages }}"
 
+- name: create CKAN temp directory
+  file: path=/var/tmp/ckan owner=www-data group=www-data mode=0755 state=directory
+
+- name: create CKAN storage directory
+  file: path=/var/lib/ckan owner=www-data group=www-data mode=0755 state=directory
+
 - name: create ckan config dir
   action: file path=/etc/ckan state=directory owner=root group=www-data mode=0750 follow=yes
 

--- a/ansible/roles/software/ckan/inventory/templates/etc/supervisor/conf.d/gunicorn-web-app.conf
+++ b/ansible/roles/software/ckan/inventory/templates/etc/supervisor/conf.d/gunicorn-web-app.conf
@@ -1,6 +1,8 @@
 [program:gunicorn-web-app]
 command={{ project_source_new_code_path }}/bin/gunicorn --paste /etc/ckan/production.ini -b localhost:5000
 directory={{ project_source_new_code_path }}
+user=www-data
+group=www-data
 stdout_logfile={{ inventory_gunicorn_error_log }}
 autostart=false
 autorestart=false


### PR DESCRIPTION
CKAN should run as www-data with both mod_wsgi or gunicorn (until we add
a dedicated ckan user).