### PR TITLE
Fix trendmicro on ckan-next hosts

### DIFF
--- a/ansible/inventories/production/group_vars/catalog-admin-v2/vars.yml
+++ b/ansible/inventories/production/group_vars/catalog-admin-v2/vars.yml
@@ -1,2 +1,5 @@
 ---
 datagov_in_service: false
+
+# Trendmicro firewall policy
+trendmicro_policy_id: "{{ trendmicro_policy_id_web }}"

--- a/ansible/inventories/production/group_vars/catalog-harvester-v2/vars.yml
+++ b/ansible/inventories/production/group_vars/catalog-harvester-v2/vars.yml
@@ -1,2 +1,5 @@
 ---
 datagov_in_service: false
+
+# Trendmicro firewall policy
+trendmicro_policy_id: "{{ trendmicro_policy_id_app }}"

--- a/ansible/inventories/production/group_vars/catalog-web-v2/vars.yml
+++ b/ansible/inventories/production/group_vars/catalog-web-v2/vars.yml
@@ -1,2 +1,5 @@
 ---
 datagov_in_service: false
+
+# Trendmicro firewall policy
+trendmicro_policy_id: "{{ trendmicro_policy_id_web }}"

--- a/ansible/inventories/production/group_vars/inventory-web-v2/vars.yml
+++ b/ansible/inventories/production/group_vars/inventory-web-v2/vars.yml
@@ -1,2 +1,5 @@
 ---
 datagov_in_service: false
+
+# Trendmicro firewall policy
+trendmicro_policy_id: "{{ trendmicro_policy_id_web }}"

--- a/ansible/inventories/staging/group_vars/catalog-admin-v2/vars.yml
+++ b/ansible/inventories/staging/group_vars/catalog-admin-v2/vars.yml
@@ -1,2 +1,5 @@
 ---
 datagov_in_service: false
+
+# Trendmicro firewall policy
+trendmicro_policy_id: "{{ trendmicro_policy_id_web }}"

--- a/ansible/inventories/staging/group_vars/catalog-harvester-v2/vars.yml
+++ b/ansible/inventories/staging/group_vars/catalog-harvester-v2/vars.yml
@@ -1,2 +1,5 @@
 ---
 datagov_in_service: false
+
+# Trendmicro firewall policy
+trendmicro_policy_id: "{{ trendmicro_policy_id_app }}"

--- a/ansible/inventories/staging/group_vars/catalog-web-v2/vars.yml
+++ b/ansible/inventories/staging/group_vars/catalog-web-v2/vars.yml
@@ -1,2 +1,5 @@
 ---
 datagov_in_service: false
+
+# Trendmicro firewall policy
+trendmicro_policy_id: "{{ trendmicro_policy_id_web }}"

--- a/ansible/inventories/staging/group_vars/inventory-web-v2/vars.yml
+++ b/ansible/inventories/staging/group_vars/inventory-web-v2/vars.yml
@@ -1,2 +1,5 @@
 ---
 datagov_in_service: false
+
+# Trendmicro firewall policy
+trendmicro_policy_id: "{{ trendmicro_policy_id_web }}"


### PR DESCRIPTION
Missed these settings when re-defining the Ansible groups in the last hotfix.