### PR TITLE
Configurable parallelism

### DIFF
--- a/ansible/actions/reboot.yml
+++ b/ansible/actions/reboot.yml
@@ -1,6 +1,6 @@
 ---
 - hosts: '!jumpbox'
-  serial: 1
+  serial: "{{ datagov_serial | default(1) }}"
   gather_facts: false
   tasks:
     - name: Check if reboot is required

--- a/ansible/catalog-web.yml
+++ b/ansible/catalog-web.yml
@@ -1,7 +1,7 @@
 ---
 - name: Catalog web stack
   hosts: catalog-web
-  serial: 1
+  serial: "{{ datagov_serial | default(1) }}"
   vars:
       app_type: catalog
 

--- a/ansible/dashboard-web.yml
+++ b/ansible/dashboard-web.yml
@@ -1,7 +1,7 @@
 ---
 - name: Provisioning Dashboard
   hosts: dashboard-web
-  serial: 1
+  serial: "{{ datagov_serial | default(1) }}"
   roles:
     - { role: software/common/tls, tags: [provision, tls] }
     - { role: software/common/php-common, tags: [provision] }
@@ -17,7 +17,7 @@
 
 - name: Deploying Dashboard
   hosts: dashboard-web
-  serial: 1
+  serial: "{{ datagov_serial | default(1) }}"
   roles:
     - { role: gsa.datagov-deploy-dashboard, tags: [deploy, provision] }
   # Host-level smoke tests

--- a/ansible/datagov-web.yml
+++ b/ansible/datagov-web.yml
@@ -1,7 +1,7 @@
 ---
 - name: Deploy Wordpress
   hosts: wordpress-web
-  serial: 1
+  serial: "{{ datagov_serial | default(1) }}"
   roles:
     - { role: software/common/tls, tags: [provision, tls] }
     - { role: software/common/php-common, tags: [provision] }
@@ -16,7 +16,7 @@
 
 - name: Deploying Data.gov
   hosts: wordpress-web
-  serial: 1
+  serial: "{{ datagov_serial | default(1) }}"
   roles:
     - { role: gsa.datagov-deploy-wordpress, tags: [deploy, provision] }
   tasks:

--- a/ansible/inventories/sandbox/group_vars/all/vars.yml
+++ b/ansible/inventories/sandbox/group_vars/all/vars.yml
@@ -73,6 +73,7 @@ dashboard_service_url: https://dashboard.sandbox.datagov.us
 datagov_enable_postgresql_role: true
 datagov_environment: sandbox
 datagov_sandbox_env: sandbox
+datagov_serial: "100%"
 
 default_tls_host_key: "{{ vault_default_tls_host_key }}"
 default_tls_host_certificate: |-

--- a/ansible/inventories/staging/group_vars/all/vars.yml
+++ b/ansible/inventories/staging/group_vars/all/vars.yml
@@ -56,6 +56,7 @@ dashboard_service_url: https://dashboard-datagov.dev-ocsit.bsp.gsa.gov
 
 # data.gov-wide variables
 datagov_environment: staging
+datagov_serial: "100%"
 
 
 default_tls_host_key: "{{ vault_default_tls_host_key }}"

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -1,7 +1,7 @@
 ---
 - name: Provisioning Inventory CKAN Stack
   hosts: inventory-web:!inventory-web-2-8
-  serial: 1
+  serial: "{{ datagov_serial | default(1) }}"
   vars:
     app_type: inventory
 

--- a/ansible/pycsw.yml
+++ b/ansible/pycsw.yml
@@ -10,7 +10,7 @@
 
 - name: CSW web
   hosts: pycsw-web,!v2
-  serial: 1
+  serial: "{{ datagov_serial | default(1) }}"
   roles:
     - role: gsa.datagov-deploy-pycsw
       pycsw_role: web


### PR DESCRIPTION
Adds `datagov_serial` to control serialization where serialization matters. For
staging, we set this to 100%, meaning no serialization, because we don't mind if
services are unavailable during critical plays and would prefer faster deploys.