### PR TITLE
[hotfix] Dashboard saml removal

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -74,5 +74,5 @@ ignore:
     - '*':
         reason: >-
           Fix not yet released https://bugzilla.redhat.com/show_bug.cgi?id=1835566
-        expires: 2020-06-15T06:00:00.000Z
+        expires: 2020-06-23T06:00:00.000Z
 patch: {}

--- a/ansible/dashboard-web.yml
+++ b/ansible/dashboard-web.yml
@@ -39,14 +39,6 @@
       delay: 10
       until: not result.failed
 
-    - name: access to simplesaml admin is forbidden
-      uri:
-        url: https://{{ ansible_fqdn }}/simplesaml/module.php/core/loginuserpass.php
-        follow_redirects: none
-        status_code: 403
-        validate_certs: false
-
-
 - name: Service-level smoke tests for dashboard
   hosts: dashboard-web
   tags: [deploy,provision]

--- a/ansible/inventories/sandbox/group_vars/all/vars.yml
+++ b/ansible/inventories/sandbox/group_vars/all/vars.yml
@@ -53,6 +53,7 @@ catalog_next_ckan_plugins_default:
   - report
   - archiver
   - datagovtheme
+  - datagovcatalog
 
 # common
 common_newrelic_enabled: false

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -43,7 +43,7 @@
   version: 1.0.4
 - name: gsa.datagov-deploy-dashboard
   src: https://github.com/GSA/datagov-deploy-dashboard
-  version: v1.0.2
+  version: v1.0.3
 - name: gsa.datagov-deploy-apache2
   src: https://github.com/GSA/datagov-deploy-apache2
   version: v1.3.1
@@ -67,7 +67,7 @@
   version: v1.1.0
 - name: gsa.datagov-deploy-wordpress
   src: https://github.com/GSA/datagov-deploy-wordpress.git
-  version: v1.0.4
+  version: v1.0.5
 - name: jnv.unattended-upgrades
   version: v1.8.0
 - name: jobscore.beats

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -43,7 +43,7 @@
   version: 1.0.4
 - name: gsa.datagov-deploy-dashboard
   src: https://github.com/GSA/datagov-deploy-dashboard
-  version: v1.0.3
+  version: v1.0.4
 - name: gsa.datagov-deploy-apache2
   src: https://github.com/GSA/datagov-deploy-apache2
   version: v1.3.1

--- a/ansible/roles/software/ckan/catalog/ckan-app/templates/catalog-next/etc_ckan_production.ini.j2
+++ b/ansible/roles/software/ckan/catalog/ckan-app/templates/catalog-next/etc_ckan_production.ini.j2
@@ -198,6 +198,7 @@ set debug = False
 
 ckan.harvest.mq.type = redis
 ckanext.harvest.email = on
+ckan.harvest.status_mail.all=True
 
 ## SAML2 Settings
 saml2.site_url = {{ saml2_site_url }}


### PR DESCRIPTION
https://github.com/GSA/datagov-deploy/issues/1777

Mainly to pull in the bump to gsa.datagov-deploy-dashboard, but the other changes should be harmless as they:
- bump TLS in wordpress
- alter catalog-next configuration which is not deployed staging/production yet