### PR TITLE
Fix CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN apk add \
   libc-dev \
   libffi-dev \
   make \
+  openssh \
   openssl-dev \
   pkgconfig
 

--- a/ansible/inventories/sandbox/group_vars/jenkins/vars.yml
+++ b/ansible/inventories/sandbox/group_vars/jenkins/vars.yml
@@ -1,0 +1,2 @@
+---
+ubu16gsa_is_router: true  # work around https://github.com/GSA/datagov-deploy/issues/1786


### PR DESCRIPTION
https://github.com/GSA/datagov-deploy/issues/1786 https://github.com/GSA/datagov-deploy/issues/1785

Adds ssh to the docker image. The porting guide to [2.8][1] wasn't clear on
this. It seems like the docker image in CI used to fallback to paramiko in the
absence of ssh. That doesn't seem to be the case with 2.8.

Since in staging/production we run with ssh, this also improves parity in those
environments.

Also includes a workaround for setting net.ipv4.ip_forward on Jenkins.

[1]: https://docs.ansible.com/ansible/devel/porting_guides/porting_guide_2.8.html