### PR TITLE
PyCSW version bump

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -58,7 +58,7 @@
   version: v2.0.1
 - name: gsa.datagov-deploy-pycsw
   src: https://github.com/GSA/datagov-deploy-pycsw
-  version: v1.0.4
+  version: v1.0.5
 - name: gsa.datagov-deploy-redis
   src: https://github.com/GSA/datagov-deploy-redis
   version: v1.0.2


### PR DESCRIPTION
Cover [new release](https://github.com/GSA/datagov-deploy-pycsw/releases/tag/1.0.5)