### PR TITLE
Replace harvest with datagov_harvest as catalog classic

### DIFF
--- a/ansible/inventories/sandbox/group_vars/all/vars.yml
+++ b/ansible/inventories/sandbox/group_vars/all/vars.yml
@@ -35,7 +35,7 @@ catalog_next_ckan_plugins_default:
   - image_view
   - text_view
   - recline_view
-  - harvest
+  - datagov_harvest
   - ckan_harvester
   - geodatagov
   - datajson


### PR DESCRIPTION
Start using the `datagov_harvest` to override harvest source form creation
Now we are not able to create `waf-collection` harvester sources.
This is the [actual behaviour of catalog classic](https://github.com/GSA/datagov-deploy/blob/1cdb5dadecbc27a683d59e753dfeaab55bccc3ce/ansible/roles/software/ckan/catalog/ckan-app/defaults/main.yml#L16).
The form add this new fields:
![image](https://user-images.githubusercontent.com/3237309/85419682-c5dba380-b548-11ea-9828-44583c25251b.png)