### PR TITLE
Newest dashboard deploy version

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -43,7 +43,7 @@
   version: 1.0.4
 - name: gsa.datagov-deploy-dashboard
   src: https://github.com/GSA/datagov-deploy-dashboard
-  version: v1.0.4
+  version: v1.0.5
 - name: gsa.datagov-deploy-apache2
   src: https://github.com/GSA/datagov-deploy-apache2
   version: v1.3.1


### PR DESCRIPTION
This is to remove pcntl from the fpm binary. This should remove our intermittent php errors on #1801 