### PR TITLE
[hotfix][redis] add hosts to inventory

### DIFF
--- a/ansible/inventories/production/group_vars/redis-catalog-next/vars.yml
+++ b/ansible/inventories/production/group_vars/redis-catalog-next/vars.yml
@@ -1,0 +1,5 @@
+---
+datagov_service: redis-catalog
+
+# Trendmicro firewall policy
+trendmicro_policy_id: "{{ trendmicro_policy_id_app }}"

--- a/ansible/inventories/production/hosts
+++ b/ansible/inventories/production/hosts
@@ -107,11 +107,15 @@ catalogharvester2p.prod-ocsit.bsp.gsa.gov
 
 [redis:children]
 redis-catalog
+redis-catalog-next
+redis-inventory-next
 
 [redis-catalog]
 catalog-harvester1p.prod-ocsit.bsp.gsa.gov
 
 [redis-catalog-next]
+redis1p.prod-ocsit.bsp.gsa.gov
+
 [redis-inventory-next]
 
 catalogharvester1p.prod-ocsit.bsp.gsa.gov
@@ -138,6 +142,8 @@ catalog-web-v2
 dashboard-web-v2
 inventory-web-v2
 jumpbox-v2
+redis-catalog-next
+redis-inventory-next
 solr
 wordpress-web-v2
 

--- a/ansible/inventories/staging/group_vars/redis-catalog-next/vars.yml
+++ b/ansible/inventories/staging/group_vars/redis-catalog-next/vars.yml
@@ -1,0 +1,5 @@
+---
+datagov_service: redis-catalog
+
+# Trendmicro firewall policy
+trendmicro_policy_id: "{{ trendmicro_policy_id_app }}"

--- a/ansible/inventories/staging/hosts
+++ b/ansible/inventories/staging/hosts
@@ -102,11 +102,15 @@ catalogharvester2d.dev-ocsit.bsp.gsa.gov
 
 [redis:children]
 redis-catalog
+redis-catalog-next
+redis-inventory-next
 
 [redis-catalog]
 catalog-harvester1d.dev-ocsit.bsp.gsa.gov
 
 [redis-catalog-next]
+redis1d.dev-ocsit.bsp.gsa.gov
+
 [redis-inventory-next]
 
 [solr]
@@ -135,6 +139,8 @@ catalog-web-v2
 dashboard-web-v2
 inventory-web-v2
 jumpbox-v2
+redis-catalog-next
+redis-inventory-next
 solr
 solr-next
 wordpress-web-v2

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -49,7 +49,7 @@
   version: v1.3.1
 - name: gsa.datagov-deploy-common
   src: https://github.com/GSA/datagov-deploy-common
-  version: v4.1.1
+  version: v4.1.2
 - name: gsa.datagov-deploy-jenkins
   src: https://github.com/GSA/datagov-deploy-jenkins
   version: v1.0.0


### PR DESCRIPTION
https://github.com/GSA/datagov-deploy/issues/1537

This adds new dedicated redis hosts for catalog-next to staging and production.

In sandbox we still use ElastiCache.