### PR TITLE
ssl only for fgdc2iso; remove port 80

### DIFF
--- a/ansible/fgdc2iso.yml
+++ b/ansible/fgdc2iso.yml
@@ -23,11 +23,7 @@
             servers:
               - "127.0.0.1:8080"
         nginx_vhosts:
-          - listen: "80"
-            server_name: "fgdc2iso"
-            filename: "fgdc2iso.80.conf"
-            return: "301 https://$host$request_uri"
-          - listen: "443"
+          - listen: "443 ssl"
             server_name: "fgdc2iso"
             filename: "fgdc2iso.443.conf"
             extra_parameters: |
@@ -52,7 +48,7 @@
 
     - name: assert app is up
       uri:
-        url: http://localhost/fgdc2iso/
+        url: https://{{ ansible_fqdn }}/fgdc2iso/
         follow_redirects: all
         method: POST
         body: |


### PR DESCRIPTION
Don't see any reason leave port 80 open. Port 80->443 redirecting for fgdc2iso POST request is not working anyway.