### PR TITLE
remove todo after cert fixed

### DIFF
--- a/ansible/fgdc2iso.yml
+++ b/ansible/fgdc2iso.yml
@@ -63,10 +63,6 @@
           </metadata>
         status_code: 200
         return_content: yes
-        # TODO enable cert validation. Staging and production hosts have GSA
-        # signed certs which should be valid.
-        # https://github.com/GSA/datagov-deploy/issues/900
-        validate_certs: false
       retries: 3
       delay: 10
       register: result


### PR DESCRIPTION
For fgdc2iso service to be working, it has to have a trusted SSL certificate.

Sandbox, staging, production all have trusted certs now. so this `validate_certs: false` is not needed any more. 