### PR TITLE
[catalog] retry smoke test

### DIFF
--- a/ansible/catalog-web.yml
+++ b/ansible/catalog-web.yml
@@ -97,3 +97,7 @@
       run_once: true
       delegate_to: localhost
       become: false
+      retries: 3
+      delay: 10
+      register: result
+      until: not result.failed


### PR DESCRIPTION
When deploying staging in parallel, there is a chance that all instances are
down for a few moments after deploy. Adds retries to the smoke test as we expect
the instances to be back up within 30 seconds.