### PR TITLE
enable port 80 on fgdc2iso

### DIFF
--- a/ansible/fgdc2iso.yml
+++ b/ansible/fgdc2iso.yml
@@ -23,6 +23,13 @@
             servers:
               - "127.0.0.1:8080"
         nginx_vhosts:
+          - listen: "80"
+            server_name: "fgdc2iso"
+            filename: "fgdc2iso.80.conf"
+            extra_parameters: |
+              location / {
+                proxy_pass http://tomcat;
+              }
           - listen: "443 ssl"
             server_name: "fgdc2iso"
             filename: "fgdc2iso.443.conf"


### PR DESCRIPTION
Bringing port 80 back to fgdc2iso tomcat server.

Basically reverting the change did in https://github.com/GSA/datagov-deploy/pull/1854