### PR TITLE
[hotfix] update snyk usage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
       - run:
           name: install snyk
           command: sudo npm install -g snyk
-      - run: snyk monitor
+      - run: snyk monitor --project-name=GSA/datagov-deploy
 
   snyk-test:
     docker:
@@ -46,7 +46,7 @@ jobs:
       - run:
           name: install snyk
           command: sudo npm install -g snyk
-      - run: snyk test
+      - run: snyk test --dev
 
   test:
     docker:

--- a/.snyk
+++ b/.snyk
@@ -9,6 +9,7 @@ ignore:
   SNYK-PYTHON-ANSIBLE-569107:
     - '*':
         reason: >-
-          Fix not yet released https://bugzilla.redhat.com/show_bug.cgi?id=1835566
-        expires: 2020-07-14T06:00:00.000Z
+          Fix not yet released https://bugzilla.redhat.com/show_bug.cgi?id=1835566. Current server security
+          sufficient to mitigate risk.
+        expires: 2020-07-23T06:00:00.000Z
 patch: {}


### PR DESCRIPTION
- Run snyk monitor with a project name so that we don't get an ambiguous
  "Project:Pipfile" in the Snyk dashboard.
- Include dev dependencies in the snyk-test as part of feature branches.