### PR TITLE
Include Ansible inventories in lint check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,10 @@ setup:
 	pipenv install --dev
 
 lint:
-	cd ansible && ansible-playbook --syntax-check $(ANSIBLE_PLAYBOOKS)
-	cd ansible && ansible-lint -v -x ANSIBLE0010 --exclude=roles/vendor *.yml
+	cd ansible && ANSIBLE_INVENTORY_ANY_UNPARSED_IS_FAILED=true ansible-playbook --syntax-check --inventory inventories/production $(ANSIBLE_PLAYBOOKS)
+	cd ansible && ANSIBLE_INVENTORY_ANY_UNPARSED_IS_FAILED=true ansible-playbook --syntax-check --inventory inventories/staging $(ANSIBLE_PLAYBOOKS)
+	cd ansible && ANSIBLE_INVENTORY_ANY_UNPARSED_IS_FAILED=true ansible-playbook --syntax-check --inventory inventories/mgmt $(ANSIBLE_PLAYBOOKS)
+	cd ansible && ansible-lint -v -x ANSIBLE0010 --exclude=roles/vendor $(ANSIBLE_PLAYBOOKS)
 
 $(MOLECULE_SUITE_TARGETS):
 	cd ansible/roles/$(subst test-molecule-,,$@) && \

--- a/ansible/actions/reboot.yml
+++ b/ansible/actions/reboot.yml
@@ -8,12 +8,5 @@
       register: reboot_required
 
     - name: Reboot host
-      shell: "sleep 1 && reboot"
-      async: 1
-      poll: 0
+      reboot: {}
       when: force_reboot is defined or reboot_required.stat.exists
-      register: rebooted
-
-    - name: Wait for host to come up
-      local_action: wait_for host={{ ansible_ssh_host }} port=22 delay=60 state=started
-      when: rebooted is not skipped

--- a/ansible/inventories/sandbox/inventory-web-2-8/vars.yml
+++ b/ansible/inventories/sandbox/inventory-web-2-8/vars.yml
@@ -1,2 +1,0 @@
----
-inventory_ckan_redis_password: "{{ inventory_next_ckan_redis_password }}"


### PR DESCRIPTION
I picked this up because I'm tweaking the hosts files for https://github.com/GSA/datagov-ckan-multi/issues/296.

I think this is the best we're going to get with https://github.com/GSA/datagov-deploy/issues/996.

If we provide the vault password to CI, we can do some more things like `ansible-inventory --graph` but I'm not sure it really buys us much more coverage. I think https://github.com/GSA/datagov-deploy/issues/700 would go pretty far.

