### PR TITLE
keep existing tomcat before ec2 ready on prod

### DIFF
--- a/ansible/roles/software/ckan/catalog/ckan-app/files/etc/cron.d/clean-tmp-files
+++ b/ansible/roles/software/ckan/catalog/ckan-app/files/etc/cron.d/clean-tmp-files
@@ -1,0 +1,2 @@
+# delete those tomcat6 tmp file older than 2 days
+0 0 * * * root find /tmp/ -type f -user tomcat6 -name "tmp*-*-*-*-*" -mtime +2 -delete

--- a/ansible/roles/software/ckan/catalog/ckan-app/handlers/main.yml
+++ b/ansible/roles/software/ckan/catalog/ckan-app/handlers/main.yml
@@ -2,6 +2,9 @@
 - name: restart redis
   service: name=redis-server state=restarted
 
+- name: restart tomcat
+  service: name={{ catalog_harvester_tomcat_service }} state=restarted
+
 - name: reload supervisor
   command: supervisorctl reload
   when:

--- a/ansible/roles/software/ckan/catalog/ckan-app/molecule/worker-next/playbook.yml
+++ b/ansible/roles/software/ckan/catalog/ckan-app/molecule/worker-next/playbook.yml
@@ -7,3 +7,4 @@
         catalog_app_type: worker
         catalog_ckan_worker_type: main_worker
         catalog_harvest_enable_harvest_report: true
+        fgdc2iso_saxon_license: blah blah blah fake saxon license

--- a/ansible/roles/software/ckan/catalog/ckan-app/molecule/worker_main/playbook.yml
+++ b/ansible/roles/software/ckan/catalog/ckan-app/molecule/worker_main/playbook.yml
@@ -7,3 +7,4 @@
         catalog_app_type: worker
         catalog_ckan_worker_type: main_worker
         catalog_harvest_enable_harvest_report: true
+        fgdc2iso_saxon_license: blah blah blah fake saxon license

--- a/ansible/roles/software/ckan/catalog/ckan-app/tasks/fgdc2iso.yml
+++ b/ansible/roles/software/ckan/catalog/ckan-app/tasks/fgdc2iso.yml
@@ -1,0 +1,29 @@
+---
+- name: assert fgdc2iso_saxon_license exists
+  fail:
+    msg: fgdc2iso_saxon_license is required but has not been defined.
+  when: fgdc2iso_saxon_license is undefined
+
+- name: include distribution-specific variables
+  include_vars: "{{ ansible_distribution_release }}.yml"
+
+- name: prepare packages needed for harvester
+  apt: name="{{ catalog_harvester_fgdc2iso_apt_packages }}" state=present
+
+  # Nessus 12085
+- name: remove default tomcat files
+  file: dest={{ catalog_harvester_tomcat_directory }}/webapps/ROOT state=absent
+
+- name: copy clean-tmp-files cron
+  copy: src=etc/cron.d/clean-tmp-files dest=/etc/cron.d/clean-tmp-files mode=0644
+
+- name: copy fgdc2iso app
+  copy: src=var/lib/tomcat6/webapps/fgdc2iso.war dest={{ catalog_harvester_tomcat_directory }}/webapps/fgdc2iso.war mode=0644
+  notify: restart tomcat
+
+- name: copy saxon-license.lic
+  copy:
+    content: |
+      {{ fgdc2iso_saxon_license }}
+    dest: /etc/saxon-license.lic
+    mode: "0644"

--- a/ansible/roles/software/ckan/catalog/ckan-app/tasks/worker.yml
+++ b/ansible/roles/software/ckan/catalog/ckan-app/tasks/worker.yml
@@ -1,4 +1,8 @@
 ---
+- include: fgdc2iso.yml
+  tags: ['fgdc2iso']
+  when: catalog_ckan_worker_type == 'main_worker'
+
 - name: Remove pip installed supervisor
   pip: name=supervisor virtualenv=/usr/lib/ckan/ state=absent
   tags:

--- a/ansible/roles/software/ckan/catalog/ckan-app/templates/etc_ckan_production.ini.j2
+++ b/ansible/roles/software/ckan/catalog/ckan-app/templates/etc_ckan_production.ini.j2
@@ -218,7 +218,7 @@ ckanext.spatial.common_map.subdomains = abc
 ckanext.spatial.common_map.attribution = Map tiles &amp; Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="https://creativecommons.org/licenses/by-sa/3.0/">CC BY SA</a>.
 ckanext.spatial.harvest.xslt_html_content = ckanext.datagovtheme:templates/xslt/iso-details.xslt
 ckanext.spatial.harvest.xslt_html_content_original = ckanext.datagovtheme:templates/xslt/esri-iso-fgdc-details.xslt
-ckanext.geodatagov.fgdc2iso_service = https://{{ catalog_ckan_fgdc2iso_host }}/fgdc2iso/
+ckanext.geodatagov.fgdc2iso_service = http://localhost:8080/fgdc2iso/
 ckanext.geodatagov.spatial_preview.url = https://climateathome.org/viewer/
 ckanext.geodatagov.spatial_preview.formats = wms kml kmz
 ckanext.geodatagov.dynamic_menu.url_default = https://www.data.gov/app/plugins/datagov-custom/wp_download_links.php

--- a/ansible/roles/software/ckan/catalog/ckan-app/vars/bionic.yml
+++ b/ansible/roles/software/ckan/catalog/ckan-app/vars/bionic.yml
@@ -1,0 +1,8 @@
+---
+catalog_harvester_fgdc2iso_apt_packages:
+  - cron
+  - default-jre
+  - tomcat8
+
+catalog_harvester_tomcat_directory: /var/lib/tomcat8
+catalog_harvester_tomcat_service: tomcat8

--- a/ansible/roles/software/ckan/catalog/ckan-app/vars/trusty.yml
+++ b/ansible/roles/software/ckan/catalog/ckan-app/vars/trusty.yml
@@ -1,0 +1,8 @@
+---
+catalog_harvester_fgdc2iso_apt_packages:
+  - cron
+  - default-jre
+  - tomcat6
+
+catalog_harvester_tomcat_directory: /var/lib/tomcat6
+catalog_harvester_tomcat_service: tomcat6


### PR DESCRIPTION
This adds tomcat back to harvester to keep existing fgdc2iso service running. This has to be done when we wait for fgdc2iso instance ready on prod.