### PR TITLE
Logging Updates

### DIFF
--- a/ansible/catalog-web.yml
+++ b/ansible/catalog-web.yml
@@ -59,9 +59,9 @@
           options:
             - compress
             - copytruncate
-            - size 512M
+            - daily
             - missingok
-            - rotate 8
+            - rotate 180
 
 
 - name: NewRelic

--- a/ansible/roles/software/ckan/catalog/ckan-app/templates/etc_ckan_production.ini.j2
+++ b/ansible/roles/software/ckan/catalog/ckan-app/templates/etc_ckan_production.ini.j2
@@ -277,13 +277,13 @@ level = WARNING
 handlers = console
 
 [logger_ckan]
-level = INFO
+level = WARNING
 handlers = console
 qualname = ckan
 propagate = 0
 
 [logger_ckanext]
-level = DEBUG
+level = WARNING
 handlers = console
 qualname = ckanext
 propagate = 0


### PR DESCRIPTION
Changes for #1833 and #1890. To comply with security protocols and limit logging to necessary information only.

May need evaluation and slight tweaks after 30 days. May eventually require larger drives for log folder.

Should lower log output by ~93%.