### PR TITLE
[gen-csr] SAN should include ALL domain names

### DIFF
--- a/ansible/bin/gen-csr.sh
+++ b/ansible/bin/gen-csr.sh
@@ -88,7 +88,7 @@ extendedKeyUsage = 1.3.6.1.5.5.7.3.1
 subjectAltName = @alt_names
 
 [ alt_names ]
-$(cat | san_hosts)
+$((echo $common_name; cat) | san_hosts)
 EOF
 )
 


### PR DESCRIPTION
Fixes the certificate validation issue with catalog-fgdc2iso1d.

When the SAN exists, CN is not checked. I don't think this was noticed before
because it had always been catalog-harvester1d in the CN until now.

From [rfc6125][1]:

> In general, this specification recommends and prefers use of
> subjectAltName entries (DNS-ID, SRV-ID, URI-ID, etc.) over use of the
> subject field (CN-ID) where possible, as more completely described in
> the following sections.

And on [checking the Common Name][2]:

> a client MUST NOT seek a match for a reference identifier
> of CN-ID if the presented identifiers include a DNS-ID, SRV-ID,
> URI-ID, or any application-specific identifier types supported by the
> client.

[1]: https://tools.ietf.org/html/rfc6125#section-2.3
[2]: https://tools.ietf.org/html/rfc6125#section-6.4.4