### PR TITLE
Fix Jenkins Config

### DIFF
--- a/ansible/templates/jenkins_config_sandbox.yml.j2
+++ b/ansible/templates/jenkins_config_sandbox.yml.j2
@@ -71,7 +71,7 @@ unclassified:
   location:
     adminAddress: "{{ datagov_team_email }}"
     url: "https://{{ jenkins_host }}/"
-  timestamperConfig:
+  timestamper:
     allPipelines: true
 
 # https://plugins.jenkins.io/job-dsl/


### PR DESCRIPTION
Jenkins was crashed and would not come up, said `timestamperConfig` was not a valid option. Changed locally on server, validated `timestamper` is the correct variable. Adding to configuration for deploy...