### PR TITLE
Capture attempts to restart harvester run

### DIFF
--- a/ansible/roles/software/ckan/catalog/ckan-app/files/etc/cron.d/ckan_main_worker
+++ b/ansible/roles/software/ckan/catalog/ckan-app/files/etc/cron.d/ckan_main_worker
@@ -1,1 +1,1 @@
-*/3 * * * * root supervisorctl start harvest-run > /dev/null
+*/3 * * * * root supervisorctl start harvest-run >> /var/log/harvester_run.log 2>&1


### PR DESCRIPTION
If starting harvester run fails, then show the error in logs `harvest-run: ERROR (already started)`

![image](https://user-images.githubusercontent.com/3237309/88962211-7fcadb80-d27c-11ea-9bd1-3bc7e98be421.png)
