### PR TITLE
[newrelic] fix CI when license key not set

### DIFF
--- a/ansible/catalog-web.yml
+++ b/ansible/catalog-web.yml
@@ -69,14 +69,20 @@
   vars:
     newrelic_app_name: catalog
   roles:
-    - monitoring/newrelic/python-agent-ansible
+    - role: monitoring/newrelic/python-agent-ansible
+      when: common_newrelic_enabled
+  tags:
+    - newrelic
 
 - name: NewRelic
   hosts: catalog-admin:!catalog-web-next
   vars:
     newrelic_app_name: catalog-admin
   roles:
-    - monitoring/newrelic/python-agent-ansible
+    - role: monitoring/newrelic/python-agent-ansible
+      when: common_newrelic_enabled
+  tags:
+    - newrelic
 
 
 - name: Service-level smoke tests

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -69,7 +69,8 @@
   vars:
     newrelic_app_name: inventory
   roles:
-    - monitoring/newrelic/python-agent-ansible
+    - role: monitoring/newrelic/python-agent-ansible
+      when: common_newrelic_enabled
   tags:
     - newrelic
 

--- a/ansible/roles/monitoring/newrelic/python-agent-ansible/defaults/main.yml
+++ b/ansible/roles/monitoring/newrelic/python-agent-ansible/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
-nrinfragent_license_key: licesense-goes-here
 ckan_config_path: '/etc/ckan'
 newrelic_config_path: '/etc/newrelic'
 newrelic_environment: production


### PR DESCRIPTION
Resolves the deploy failure https://github.com/GSA/datagov-deploy/issues/1952

Instead of assuming an dummy default license key, explicitly condition on
common_newrelic_enabled.