### PR TITLE
[inventory-next] fix CI

### DIFF
--- a/ansible/inventories/sandbox/hosts
+++ b/ansible/inventories/sandbox/hosts
@@ -9,6 +9,7 @@
 [tag_group_efk_nginx]
 [tag_group_elasticsearch]
 [tag_group_inventory_web]
+[tag_group_inventory_web_next]
 [tag_group_inventory_web_2_8]
 [tag_group_jenkins]
 [tag_group_jumpbox]
@@ -49,6 +50,7 @@ tag_group_inventory_web
 
 [inventory-web-2-8:children]
 tag_group_inventory_web_2_8
+tag_group_inventory_web_next
 
 [jenkins:children]
 tag_group_jenkins

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -1,6 +1,6 @@
 ---
 - name: Provisioning Inventory CKAN Stack
-  hosts: inventory-web:!inventory-web-2-8
+  hosts: inventory-web:!inventory-web-2-8:!inventory-web-next
   serial: "{{ datagov_serial | default(1) }}"
   vars:
     app_type: inventory
@@ -65,7 +65,7 @@
 
 
 - name: NewRelic
-  hosts: inventory-web:!inventory-web-2-8
+  hosts: inventory-web:!inventory-web-2-8:!inventory-web-next
   vars:
     newrelic_app_name: inventory
   roles:
@@ -76,7 +76,7 @@
 
 
 - name: Service-level smoke tests
-  hosts: inventory-web:!inventory-web-2-8
+  hosts: inventory-web:!inventory-web-2-8:!inventory-web-next
   tasks:
     - name: flush handlers
       meta: flush_handlers


### PR DESCRIPTION
https://github.com/GSA/datagov-deploy/issues/1952

Add inventory-next to Ansible inventory so it's not pulled into inventory-web.