### PR TITLE
Version bumps and variable addition

### DIFF
--- a/ansible/group_vars/all/vars.yml
+++ b/ansible/group_vars/all/vars.yml
@@ -138,7 +138,7 @@ datagov_operators_test:
     active: false
 
 # Limit SSH Access
-jumpbox_ips: "10.*.*.*"
+jumpbox_ips: "10.0.0.0/8"
 
 
 # newrelic monitoring

--- a/ansible/group_vars/all/vars.yml
+++ b/ansible/group_vars/all/vars.yml
@@ -137,6 +137,9 @@ datagov_operators_test:
     public_key: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDOc4Jh25ibG2ZxoeOJ8fPShoGJNcmU0S0qc4xCda/OcMf8Jtm/jWdUqWAA8vDTUu9tUTjS1aoEd+RsDxsXoQfbi4Za6HBT54qa4CmocEX6XQsdSn7gxFkSMD1KrZHE6Vk26lgmr9mDshcPFdwHXrqmOudZQhfN4CxiAo1E+pbIMhD2UJ/0PPVt/3myAHyywxNymPO0gl/gC1g6UAtidwDwGuWc1m7Fshw2BTt9FYPI4ItepBwps2Kn9+Ze7O1boytr8hoFnlpSJdq/G34YierDkN+yrM5251SkDmK6btjfwdEEkQlBQPkuHSkXUIgjs+YKtOgIUnk8eDFt4rTq8ok/ yaditi.dave@gsa.gov
     active: false
 
+# Limit SSH Access
+jumpbox_ips: "10.*.*.*"
+
 
 # newrelic monitoring
 newrelic_environment: "{{ datagov_environment | default('unknown') }}"

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -49,7 +49,7 @@
   version: v1.3.1
 - name: gsa.datagov-deploy-common
   src: https://github.com/GSA/datagov-deploy-common
-  version: v4.1.3
+  version: v4.1.4
 - name: gsa.datagov-deploy-fgdc2iso
   src: https://github.com/GSA/datagov-deploy-fgdc2iso
   version: v1.0.0
@@ -58,7 +58,7 @@
   version: v1.0.0
 - name: gsa.datagov-deploy-jumpbox
   src: https://github.com/GSA/datagov-deploy-jumpbox
-  version: v2.0.1
+  version: v2.1.0
 - name: gsa.datagov-deploy-pycsw
   src: https://github.com/GSA/datagov-deploy-pycsw
   version: v1.0.5


### PR DESCRIPTION
Addresses #1203 and #1837. Pulls in changes from [jumpbox configuration changes](https://github.com/GSA/datagov-deploy-jumpbox/pull/10) and [common playbook changes](https://github.com/GSA/datagov-deploy-common/pull/56), and sets the `jumpbox_ips` variable. 

**Will require manual cleanup of all authorized_keys on all servers to be managed correctly moving forward.**