### PR TITLE
Make an array

### DIFF
--- a/ansible/group_vars/all/vars.yml
+++ b/ansible/group_vars/all/vars.yml
@@ -138,7 +138,7 @@ datagov_operators_test:
     active: false
 
 # Limit SSH Access
-jumpbox_ips: "10.0.0.0/8"
+jumpbox_ips: ["10.0.0.0/8"]
 
 
 # newrelic monitoring


### PR DESCRIPTION
The join on a simple text field does a join for each character, this variable **must** be an array.