### PR TITLE
catalog-next use repoze.who 2.3

### DIFF
--- a/ansible/roles/software/ckan/catalog/ckan-app/tasks/main.yml
+++ b/ansible/roles/software/ckan/catalog/ckan-app/tasks/main.yml
@@ -98,7 +98,9 @@
     virtualenv: "{{ project_source_new_code_path }}"
     umask: '0022'
     state: present
-  when: not catalog_ckan_saml2_enabled
+  when:
+    - not catalog_ckan_saml2_enabled
+    - "'v2' not in group_names"
   notify:
     - reload apache2
     - reload supervisor


### PR DESCRIPTION
eliminate circleci error `AssertionError: assert '2.3' == '2.0'` on catalog-next.