### PR TITLE
Add Google Analytics to the sandox

### DIFF
--- a/ansible/inventories/sandbox/group_vars/all/vars.yml
+++ b/ansible/inventories/sandbox/group_vars/all/vars.yml
@@ -56,6 +56,7 @@ catalog_next_ckan_plugins_default:
   - archiver
   - datagovtheme
   - datagovcatalog
+  - googleanalyticsbasic
 
 # common
 common_newrelic_enabled: false

--- a/ansible/roles/software/ckan/catalog/ckan-app/templates/catalog-next/etc_ckan_production.ini.j2
+++ b/ansible/roles/software/ckan/catalog/ckan-app/templates/catalog-next/etc_ckan_production.ini.j2
@@ -221,6 +221,9 @@ saml2.organization_mapping =
 saml2.max_redirect_slo =
 saml2.max_security_level = https://max.gov/icam/2015/10/securityLevels/securePlus2
 
+# Google Analytics
+googleanalytics.ids = UA-1010101-1 UA-1010101-2
+
 # ckanext-geodatagov settings
 
 ckanext.geodatagov.bureau_csv.url=https://resources.data.gov/schemas/dcat-us/v1.1/omb_bureau_codes.csv


### PR DESCRIPTION
Related to [Multi#364](https://github.com/GSA/datagov-ckan-multi/issues/364)

Continue PRs from
 - Analytics extension https://github.com/GSA/ckanext-googleanalyticsbasic/pull/2 (no permission to add you as reviewer)
 - New catalog https://github.com/GSA/catalog.data.gov/pull/97/

This PR:
 - Add Analytics extension
 - Add Tracker IDs