### PR TITLE
update datagov-deploy-apache2 for /var/run/apache2 permission

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -46,7 +46,7 @@
   version: v1.0.5
 - name: gsa.datagov-deploy-apache2
   src: https://github.com/GSA/datagov-deploy-apache2
-  version: v1.3.1
+  version: v1.3.2
 - name: gsa.datagov-deploy-common
   src: https://github.com/GSA/datagov-deploy-common
   version: v4.1.5


### PR DESCRIPTION
go together with https://github.com/GSA/datagov-deploy-apache2/pull/22 when new tag is ready