### PR TITLE
[catalog-next] re-enable GA

### DIFF
--- a/ansible/group_vars/catalog-next/vars.yml
+++ b/ansible/group_vars/catalog-next/vars.yml
@@ -30,3 +30,4 @@ catalog_ckan_plugins_default:
   - archiver
   - datagovtheme
   - datagovcatalog
+  - googleanalyticsbasic


### PR DESCRIPTION
I had removed this to work around an error while waiting for the extension to
be added to catalog-next (https://github.com/GSA/catalog.data.gov/pull/97).