### PR TITLE
[postfix] fix bad TLS key path

### DIFF
--- a/ansible/group_vars/all/vars.yml
+++ b/ansible/group_vars/all/vars.yml
@@ -148,6 +148,10 @@ php_mysql_package: "php{{ php_major_minor_version }}-mysql"
 # for php-versions role
 php_version: "{{ php_major_minor_version }}"
 
+# postfix
+postfix_smtpd_tls_key_file: "{{ default_tls_host_key_filepath }}"
+postfix_smtpd_tls_cert_file: "{{ default_tls_host_certificate_filepath }}"
+
 # solr
 solr_home: /data/solr5
 solr_version: 5.5.5

--- a/ansible/inventories/production/group_vars/all/vars.yml
+++ b/ansible/inventories/production/group_vars/all/vars.yml
@@ -199,8 +199,6 @@ postfix_relayhost: smtp.gsa.gov
 postfix_relayhost_port: 25
 postfix_relaytls: true
 postfix_sasl_auth_enable: false
-postfix_smtpd_tls_cert_file: /etc/ssl/certs/datagov_host.crt
-postfix_smtpd_tls_key_file: /etc/ssl/certs/datagov_host.key
 postfix_aliases:
   - user: postmaster
     alias: root

--- a/ansible/inventories/sandbox/group_vars/all/vars.yml
+++ b/ansible/inventories/sandbox/group_vars/all/vars.yml
@@ -215,8 +215,6 @@ postfix_install:
   - sasl2-bin
   - libsasl2-modules
 postfix_mailname: datagov.us
-postfix_smtpd_tls_cert_file: /etc/ssl/certs/datagov_host.crt
-postfix_smtpd_tls_key_file: /etc/ssl/certs/datagov_host.key
 postfix_inet_interfaces: loopback-only  # only listen on loopback interfaces, we don't except remote mail from remote sources.
 #postfix_default_database_type: regexp
 postfix_sender_canonical_maps:

--- a/ansible/inventories/staging/group_vars/all/vars.yml
+++ b/ansible/inventories/staging/group_vars/all/vars.yml
@@ -220,8 +220,6 @@ postfix_relayhost: smtp.gsa.gov
 postfix_relayhost_port: 25
 postfix_relaytls: true
 postfix_sasl_auth_enable: false
-postfix_smtpd_tls_cert_file: /etc/ssl/certs/datagov_host.crt
-postfix_smtpd_tls_key_file: /etc/ssl/certs/datagov_host.key
 postfix_aliases:
   - user: postmaster
     alias: root


### PR DESCRIPTION
Spotted this when debugging https://github.com/GSA/datagov-deploy/issues/1795

Looks like a bad refactor. TLS key exists in /etc/ssl/private. Use the playbook
variable across all environments.