### PR TITLE
[postfix] fix sandbox rejecting mail

### DIFF
--- a/ansible/inventories/sandbox/group_vars/all/vars.yml
+++ b/ansible/inventories/sandbox/group_vars/all/vars.yml
@@ -233,7 +233,7 @@ postfix_transport_maps:
 postfix_raw_options:
   - |
     # Postfix needs a value set https://github.com/GSA/datagov-deploy/issues/1795
-    smtpd_recipient_restrictions = reject
+    smtpd_relay_restrictions = permit_mynetworks, reject_unauth_destination
 # Configure postfix as an email sink: rewrite all recipients to root local user
 #postfix_recipient_canonical_maps:
 #  - recipient: /./  # regexp to match all addresses


### PR DESCRIPTION
Our fix for https://github.com/GSA/datagov-deploy/issues/1795 was too
restrictive. We still want to allow mail from localhost (and then discard it),
which means enabling `permit_mynetworks`.

This fixes errors in harvesting where postfix rejects messages.

Instead of seeing errors like:
```
Aug 13 21:33:11 catalog-harvester-next1tf postfix/smtpd[12244]: connect from localhost[127.0.0.1]
Aug 13 21:33:11 catalog-harvester-next1tf postfix/smtpd[12244]: NOQUEUE: reject: RCPT from localhost[127.0.0.1]: 554 5.7.1 <aaron.borden@gsa.gov>: Recipient address rejected: Access denied; from=<no-reply@datagov.us> to=<aaron.borden@gsa.gov> proto=ESMTP helo=<catalog-harvester-next1tf.internal.sandbox.datagov.us>
Aug 13 21:33:11 catalog-harvester-next1tf postfix/smtpd[12244]: disconnect from localhost[127.0.0.1] ehlo=1 mail=1 rcpt=0/1 rset=1 quit=1 commands=4/5
```

Now we see:
```
Aug 13 21:48:11 catalog-harvester-next1tf postfix/smtpd[15176]: connect from localhost[127.0.0.1]
Aug 13 21:48:11 catalog-harvester-next1tf postfix/smtpd[15176]: E4E807D050: client=localhost[127.0.0.1]
Aug 13 21:48:11 catalog-harvester-next1tf postfix/cleanup[15180]: E4E807D050: message-id=<20200813214811.E4E807D050@catalog-harvester-next1tf.internal.sandbox.datagov.us>
Aug 13 21:48:11 catalog-harvester-next1tf postfix/qmgr[14242]: E4E807D050: from=<no-reply@datagov.us>, size=1779, nrcpt=1 (queue active)
Aug 13 21:48:11 catalog-harvester-next1tf postfix/smtpd[15176]: disconnect from localhost[127.0.0.1] ehlo=1 mail=1 rcpt=1 data=1 quit=1 commands=5
Aug 13 21:48:11 catalog-harvester-next1tf postfix/smtpd[15176]: connect from localhost[127.0.0.1]
Aug 13 21:48:11 catalog-harvester-next1tf postfix/smtpd[15176]: E6DB97D132: client=localhost[127.0.0.1]
Aug 13 21:48:11 catalog-harvester-next1tf postfix/cleanup[15180]: E6DB97D132: message-id=<20200813214811.E6DB97D132@catalog-harvester-next1tf.internal.sandbox.datagov.us>
Aug 13 21:48:11 catalog-harvester-next1tf postfix/qmgr[14242]: E6DB97D132: from=<no-reply@datagov.us>, size=1785, nrcpt=1 (queue active)
Aug 13 21:48:11 catalog-harvester-next1tf postfix/discard[15181]: E4E807D050: to=<aaron.borden@gsa.gov>, relay=none, delay=0.02, delays=0.01/0.01/0/0, dsn=2.0.0, status=sent (gsa.gov)
Aug 13 21:48:11 catalog-harvester-next1tf postfix/qmgr[14242]: E4E807D050: removed
```