### PR TITLE
[catalog-next] add fgdc2iso service to sandbox

### DIFF
--- a/ansible/inventories/sandbox/group_vars/all/vars.yml
+++ b/ansible/inventories/sandbox/group_vars/all/vars.yml
@@ -26,6 +26,7 @@ catalog_db_user: "{{ catalog_ckan_db_user }}"
 
 # catalog-next
 catalog_next_ckan_db_name: catalog_db_next
+catalog_next_ckan_fgdc2iso_host: catalog-next-fgdc2iso1tf.internal.sandbox.datagov.us
 catalog_next_ckan_redis_host: master.rep-sandbox-catalog-next.5kspe7.use1.cache.amazonaws.com
 catalog_next_ckan_redis_password: "{{ vault_catalog_next_ckan_redis_password }}"
 catalog_next_ckan_redis_url: "rediss://:{{ catalog_ckan_redis_password }}@{{ catalog_ckan_redis_host }}:6379/0"

--- a/ansible/inventories/sandbox/group_vars/catalog-next/vars.yml
+++ b/ansible/inventories/sandbox/group_vars/catalog-next/vars.yml
@@ -6,6 +6,7 @@ catalog_ckan_db_host: "{{ catalog_next_postgresql_login_host }}"
 catalog_ckan_db_name: "{{ catalog_next_ckan_db_name }}"
 catalog_ckan_db_pass: "{{ catalog_next_postgresql_login_password }}"
 catalog_ckan_db_user: "{{ catalog_next_postgresql_login_user }}"
+catalog_ckan_fgdc2iso_host: "{{ catalog_next_ckan_fgdc2iso_host }}"
 
 catalog_ckan_redis_url: "{{ catalog_next_ckan_redis_url }}"
 catalog_ckan_redis_host: "{{ catalog_next_ckan_redis_host }}"

--- a/ansible/inventories/sandbox/hosts
+++ b/ansible/inventories/sandbox/hosts
@@ -6,6 +6,7 @@
 
 [catalog-fgdc2iso]
 catalog-fgdc2iso1tf.internal.sandbox.datagov.us
+catalog-next-fgdc2iso1tf.internal.sandbox.datagov.us
 
 [catalog-harvester]
 catalog-harvester1tf.internal.sandbox.datagov.us


### PR DESCRIPTION
Adds an fgdc2iso service for catalog-next in sandbox. For staging/production,
we can share the existing service.