### PR TITLE
Update retry

### DIFF
--- a/ansible/roles/software/ckan/inventory/templates/etc/apache2/sites-enabled/ckan.conf
+++ b/ansible/roles/software/ckan/inventory/templates/etc/apache2/sites-enabled/ckan.conf
@@ -10,7 +10,7 @@ WSGISocketPrefix /var/run/wsgi
 
     #gunicorn configuration
     ProxyPreserveHost On
-    ProxyPass / http://127.0.0.1:5000/ retry=10
+    ProxyPass / http://127.0.0.1:5000/ retry=1
     ProxyPassReverse / http://127.0.0.1:5000/
 
 

--- a/ansible/roles/software/ckan/inventory/templates/etc/apache2/sites-enabled/ckan.conf
+++ b/ansible/roles/software/ckan/inventory/templates/etc/apache2/sites-enabled/ckan.conf
@@ -10,8 +10,8 @@ WSGISocketPrefix /var/run/wsgi
 
     #gunicorn configuration
     ProxyPreserveHost On
-    ProxyPass / http://0.0.0.0:5000/
-    ProxyPassReverse / http://0.0.0.0:5000/
+    ProxyPass / http://127.0.0.1:5000/ retry=10
+    ProxyPassReverse / http://127.0.0.1:5000/
 
 
     # fix Cross-Frame Scripting (XFS) vulnerability

--- a/ansible/roles/software/ckan/inventory/templates/etc/supervisor/conf.d/gunicorn-web-app.conf
+++ b/ansible/roles/software/ckan/inventory/templates/etc/supervisor/conf.d/gunicorn-web-app.conf
@@ -1,5 +1,5 @@
 [program:gunicorn-web-app]
-command={{ project_source_new_code_path }}/bin/gunicorn --worker-class gevent --paste /etc/ckan/production.ini -b localhost:5000
+command={{ project_source_new_code_path }}/bin/gunicorn --worker-class gevent --paste /etc/ckan/production.ini -b localhost:5000 --proxy-allow-from="127.0.0.1"
 directory={{ project_source_new_code_path }}
 user=www-data
 group=www-data


### PR DESCRIPTION
So, according to [documentation](https://httpd.apache.org/docs/2.4/howto/reverse_proxy.html), it looks like we should be specific in proxying to localhost instead of `0.0.0.0`. Also, we noticed [timeout issues when the app was starting up](https://github.com/GSA/datagov-deploy/issues/2030), causing apache2 to wait for 60 seconds. This moves that down to 10 seconds, setting described [here](https://stackoverflow.com/questions/23709832/ap-proxy-connect-backend-disabling-worker-for-127-0-0-1).

@adborden thoughts on the specific timing, do we want 10, 30, 0?