### PR TITLE
[common] bump for python dbm support

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -49,7 +49,7 @@
   version: v1.3.2
 - name: gsa.datagov-deploy-common
   src: https://github.com/GSA/datagov-deploy-common
-  version: v4.1.5
+  version: v4.2.0
 - name: gsa.datagov-deploy-fgdc2iso
   src: https://github.com/GSA/datagov-deploy-fgdc2iso
   version: v1.0.0


### PR DESCRIPTION
https://github.com/GSA/datagov-ckan-multi/issues/359

Add support to rebuild python with dbm support, a dependency for pysaml v4.9.0.