### PR TITLE
[hotfix] add newrelic_app_name to production

### DIFF
--- a/ansible/inventories/production/group_vars/catalog-web/vars.yml
+++ b/ansible/inventories/production/group_vars/catalog-web/vars.yml
@@ -3,6 +3,8 @@
 ckan_session_store_type: memory
 datagov_service: catalog
 
+newrelic_app_name: catalog
+
 # role url
 url_readonly: "{{ urls_public.catalog }}"
 url_writable: https://admin-catalog.data.gov

--- a/ansible/inventories/production/host_vars/catalogpub-web1p.prod-ocsit.bsp.gsa.gov/vars.yml
+++ b/ansible/inventories/production/host_vars/catalogpub-web1p.prod-ocsit.bsp.gsa.gov/vars.yml
@@ -16,3 +16,7 @@ catalog_pycsw_db_name: "{{ vault_catalog_pycsw_db_name }}"
 
 # other
 catalog_ckan_solr_host: datagov-solrm1p.prod-ocsit.bsp.gsa.gov
+
+# Since catalog-admin and catalog-web have the same variable precendence (and
+# catalog-web wins), we override the app name here in host vars.
+newrelic_app_name: catalog-admin

--- a/ansible/roles/monitoring/newrelic/python-agent-ansible/tasks/main.yml
+++ b/ansible/roles/monitoring/newrelic/python-agent-ansible/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: Assert newrelic_app_name is set
+  fail:
+    msg: newrelic_app_name is required but it is not set
+  when: newrelic_app_name is undefined
 
 - name: Install the New Relic Python agent
   pip: name=newrelic virtualenv=/usr/lib/ckan umask=022


### PR DESCRIPTION
Accidentally was lost in the refactor. Fixes role failing with undefined
variable.