### PR TITLE
Change the default profile to validate WAF sources

### DIFF
--- a/ansible/roles/software/ckan/catalog/ckan-app/templates/catalog-next/etc_ckan_production.ini.j2
+++ b/ansible/roles/software/ckan/catalog/ckan-app/templates/catalog-next/etc_ckan_production.ini.j2
@@ -126,6 +126,7 @@ ckan.plugins = {{ (catalog_ckan_plugins_default + catalog_ckan_plugins_additiona
 # (plugins must be loaded in ckan.plugins)
 #ckan.views.default_views = image_view text_view recline_view
 
+ckan.spatial.validator.profiles = iso19139ngdc
 
 ## Front-End Settings
 ckan.site_title = CKAN


### PR DESCRIPTION
Related to [Multi#386](https://github.com/GSA/datagov-ckan-multi/issues/386)

This PR:
 - Change the default profile to validate XML from WAF harvest sources