### PR TITLE
[inventory] enable saml2 authentication in sandbox

### DIFF
--- a/ansible/inventories/sandbox/group_vars/catalog-web/vars.yml
+++ b/ansible/inventories/sandbox/group_vars/catalog-web/vars.yml
@@ -24,6 +24,10 @@ catalog_ckan_instance_secret: "{{ vault_catalog_ckan_instance_secret }}"
 catalog_ckan_instance_uuid: "{{ vault_catalog_ckan_instance_uuid }}"
 catalog_ckan_token_dat: "{{ vault_catalog_ckan_token_dat }}"
 catalog_ckan_who_secure: "true"
+# uncomment to enable saml2 authentication
+#catalog_ckan_saml2_enabled: true
+#catalog_ckan_plugins_additional: [saml2]
+saml2_site_url: https://catalog.sandbox.datagov.us/
 
 postgresql_login_host: "{{ catalog_postgresql_login_host }}"
 postgresql_login_password: "{{ catalog_postgresql_login_password }}"

--- a/ansible/inventories/sandbox/group_vars/inventory-next/vars.yml
+++ b/ansible/inventories/sandbox/group_vars/inventory-next/vars.yml
@@ -30,8 +30,10 @@ ckan_site_domain: "{{ inventory_next_ckan_service_url }}"
 
 inventory_app_repo_branch: inventory_ckan_2.8
 
-# max login
-saml2_site_url: unset
+# saml2 authentication
+catalog_ckan_saml2_enabled: true
+catalog_ckan_plugins_additional: [saml2]
+saml2_site_url: https://inventory-next.sandbox.datagov.us/
 
 # redis
 inventory_ckan_redis_password: "{{ inventory_next_ckan_redis_password }}"

--- a/ansible/inventories/sandbox/group_vars/inventory-web/vars.yml
+++ b/ansible/inventories/sandbox/group_vars/inventory-web/vars.yml
@@ -23,8 +23,10 @@ inventory_ckan_bucket_name: "{{ inventory_ckan_s3_bucket_name }}"
 inventory_ckan_bucket_prefix: "{{ inventory_ckan_s3_bucket_prefix }}"
 ckan_site_domain: "{{ inventory_ckan_service_url }}"
 
-# max login
-saml2_site_url: unset
+# saml2 authentication
+catalog_ckan_saml2_enabled: true
+catalog_ckan_plugins_additional: [saml2]
+saml2_site_url: https://inventory.sandbox.datagov.us/
 
 # secrets
 ckan_instance_secret: "{{ inventory_ckan_instance_secret }}"

--- a/ansible/roles/software/ckan/catalog/ckan-app/defaults/main.yml
+++ b/ansible/roles/software/ckan/catalog/ckan-app/defaults/main.yml
@@ -77,5 +77,6 @@ who_secure: "False"
 token_dat: placeholder-token
 catalog_ckan_redis_host: localhost
 catalog_ckan_fgdc2iso_host: localhost
+ckan_catalog_next: false
 ckan_production_ini_template: etc_ckan_production.ini.j2
 ckan_uses_gunicorn: false

--- a/ansible/roles/software/ckan/catalog/ckan-app/molecule/saml2/tests/test_default.py
+++ b/ansible/roles/software/ckan/catalog/ckan-app/molecule/saml2/tests/test_default.py
@@ -43,7 +43,7 @@ def test_saml2_dir(host):
 
 
 def test_saml2_attributes(host):
-    attributes = host.file('/etc/ckan/saml2/basic.py')
+    attributes = host.file('/etc/ckan/saml2/attributemaps/basic.py')
 
     assert attributes.exists
     assert attributes.user == 'root'
@@ -52,7 +52,7 @@ def test_saml2_attributes(host):
 
 
 def test_saml2_uri(host):
-    uri = host.file('/etc/ckan/saml2/saml_uri.py')
+    uri = host.file('/etc/ckan/saml2/attributemaps/saml_uri.py')
 
     assert uri.exists
     assert uri.user == 'root'

--- a/ansible/roles/software/ckan/catalog/ckan-app/tasks/main.yml
+++ b/ansible/roles/software/ckan/catalog/ckan-app/tasks/main.yml
@@ -100,7 +100,7 @@
     state: present
   when:
     - not catalog_ckan_saml2_enabled
-    - "'v2' not in group_names"
+    - not ckan_catalog_next
   notify:
     - reload apache2
     - reload supervisor

--- a/ansible/roles/software/ckan/catalog/ckan-app/tasks/saml2.yml
+++ b/ansible/roles/software/ckan/catalog/ckan-app/tasks/saml2.yml
@@ -15,9 +15,21 @@
 - name: create pki directory
   action: file path=/etc/ckan/saml2/pki state=directory mode=0750 owner=root group=www-data
 
+- name: create attributemaps directory
+  action: file path=/etc/ckan/saml2/attributemaps state=directory mode=0755 owner=root group=www-data
+
+# TODO remove me after https://github.com/GSA/datagov-deploy/issues/1968
+# Cleanup fallout #1968
+- name: copy all needed files
+  file: dest=/etc/ckan/saml2/{{ item }} state=absent
+  with_items:
+    - basic.py
+    - saml_uri.py
+  notify: reload apache2
+
 # TODO configuration files should live in the application repo
 - name: copy all needed files
-  copy: src=saml2/ dest=/etc/ckan/saml2/ mode=0644 owner=root group=www-data
+  copy: src=saml2/ dest=/etc/ckan/saml2/attributemaps mode=0644 owner=root group=www-data
   notify: reload apache2
 
 - name: install saml2 host key

--- a/ansible/roles/software/ckan/saml2/tasks/main.yml
+++ b/ansible/roles/software/ckan/saml2/tasks/main.yml
@@ -5,8 +5,21 @@
 - name: create pki directory
   action: file path=/etc/ckan/saml2/pki state=directory mode=0750 owner=root group=www-data
 
+- name: create attributemaps directory
+  action: file path=/etc/ckan/saml2/attributemaps state=directory mode=0755 owner=root group=www-data
+
+# TODO remove me after https://github.com/GSA/datagov-deploy/issues/1968
+# Cleanup fallout #1968
 - name: copy all needed files
-  action: copy src=etc/ckan/saml2/ dest=/etc/ckan/saml2/ mode=0644 owner=root group=www-data
+  file: dest=/etc/ckan/saml2/{{ item }} state=absent
+  with_items:
+    - basic.py
+    - saml_uri.py
+  notify: reload apache2
+
+# TODO configuration files should live in the application repo
+- name: copy all needed files
+  action: copy src=etc/ckan/saml2/ dest=/etc/ckan/saml2/attributemaps mode=0644 owner=root group=www-data
   notify: reload apache2
 
 - name: template all needed files


### PR DESCRIPTION
https://github.com/GSA/datagov-deploy/issues/1186 https://github.com/GSA/datagov-deploy/issues/1968

This enables MAX.gov/SAML2 authentication in sandbox for inventory and
inventory-next (although inventory-next is currently showing a gateway error).

Allows the ckan-multi folks (with GSA creds) to test and QA within sandbox.