### PR TITLE
Smoke tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ ANSIBLE_PLAYBOOKS := \
   pycsw.yml \
   redis.yml \
   site.yml \
+  smoke.yml \
   solr.yml
 
 # Create test-molecule-<suite>-<scenario> targets

--- a/ansible/datagov-web.yml
+++ b/ansible/datagov-web.yml
@@ -63,9 +63,9 @@
       until: not contact_forms.failed
 
     - name: assert Location header contains /contact
-      fail:
-        msg: "Expected Location {{ expected_url }} to be in {{ item.location }}"
-      when: expected_url not in item.location
+      assert:
+        that: expected_url in item.location
+        fail_msg: "Expected Location {{ expected_url }} to be in {{ item.location }}"
       vars:
         expected_url: "{{ ansible_fqdn }}/contact"
       loop: "{{ contact_forms.results }}"

--- a/ansible/pycsw.yml
+++ b/ansible/pycsw.yml
@@ -39,9 +39,9 @@
       until: not csw_collection.failed
 
     - name: assert csw-collection response has title
-      fail:
-        msg: csw-collection response did not contain ows:Title attribute
-      when: csw_collection.content is not search("<ows:Title>CSW interface for catalog.data.gov</ows:Title>")
+      assert:
+        that: csw_collection.content is search("<ows:Title>CSW interface for catalog.data.gov</ows:Title>")
+        fail_msg: csw-collection response did not contain ows:Title attribute
 
     - name: assert csw-all is up
       uri:
@@ -62,9 +62,9 @@
       until: not csw_all.failed
 
     - name: assert csw-all response has title
-      fail:
-        msg: csw-all response did not contain ows:Title attribute
-      when: csw_all.content is not search("<ows:Title>CSW interface for catalog.data.gov</ows:Title>")
+      assert:
+        that: csw_all.content is search("<ows:Title>CSW interface for catalog.data.gov</ows:Title>")
+        fail_msg: csw-all response did not contain ows:Title attribute
 
 
 - name: CSW worker
@@ -98,9 +98,9 @@
       become: false
 
     - name: assert csw-collection response has title
-      fail:
-        msg: csw-collection response did not contain ows:Title attribute
-      when: csw_collection.content is not search("<ows:Title>CSW interface for catalog.data.gov</ows:Title>")
+      assert:
+        that: csw_collection.content is search("<ows:Title>CSW interface for catalog.data.gov</ows:Title>")
+        fail_msg: csw-collection response did not contain ows:Title attribute
       run_once: true
       delegate_to: localhost
       become: false
@@ -121,9 +121,9 @@
       become: false
 
     - name: assert csw-all response has title
-      fail:
-        msg: csw-all response did not contain ows:Title attribute
-      when: csw_all.content is not search("<ows:Title>CSW interface for catalog.data.gov</ows:Title>")
+      assert:
+        that: csw_all.content is search("<ows:Title>CSW interface for catalog.data.gov</ows:Title>")
+        fail_msg: csw-all response did not contain ows:Title attribute
       run_once: true
       delegate_to: localhost
       become: false

--- a/ansible/roles/monitoring/newrelic/python-agent-ansible/tasks/main.yml
+++ b/ansible/roles/monitoring/newrelic/python-agent-ansible/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 - name: Assert newrelic_app_name is set
-  fail:
-    msg: newrelic_app_name is required but it is not set
-  when: newrelic_app_name is undefined
+  assert:
+    that: newrelic_app_name is defined
+    fail_msg: newrelic_app_name is required but it is not set
 
 - name: Install the New Relic Python agent
   pip: name=newrelic virtualenv=/usr/lib/ckan umask=022

--- a/ansible/roles/software/ckan/catalog/ckan-app/tasks/main.yml
+++ b/ansible/roles/software/ckan/catalog/ckan-app/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 - name: assert catalog_ckan_who_ini_secret is set
-  fail:
-    msg: catalog_ckan_who_ini_secret is not set but is required
-  when: catalog_ckan_who_ini_secret is undefined
+  assert:
+    that: catalog_ckan_who_ini_secret is defined
+    fail_msg: catalog_ckan_who_ini_secret is not set but is required
 
 # Since ckanext-saml2 and its dependencies are part of catalog-app's requirements.txt, their
 # build dependencies must be installed even if saml2 will not be enabled.

--- a/ansible/roles/software/ckan/catalog/ckan-app/tasks/saml2.yml
+++ b/ansible/roles/software/ckan/catalog/ckan-app/tasks/saml2.yml
@@ -1,13 +1,13 @@
 ---
 - name: assert saml2_sp_public_certificate is set
-  fail:
-    msg: saml2_sp_public_certificate is required
-  when: saml2_sp_public_certificate is undefined
+  assert:
+    that: saml2_sp_public_certificate is defined
+    fail_msg: saml2_sp_public_certificate is required
 
 - name: assert saml2_sp_private_key is set
-  fail:
-    msg: saml2_sp_private_key is required
-  when: saml2_sp_private_key is undefined
+  assert:
+    that: saml2_sp_private_key is defined
+    fail_msg: saml2_sp_private_key is required
 
 - name: create saml2 directory
   action: file path=/etc/ckan/saml2/ state=directory mode=0755 owner=root group=www-data

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -17,3 +17,7 @@
 - import_playbook: dashboard-web.yml
 - import_playbook: datagov-web.yml
 - import_playbook: inventory.yml
+
+# Validation and cleanup
+#########################
+- import_playbook: smoke.yml

--- a/ansible/smoke.yml
+++ b/ansible/smoke.yml
@@ -1,6 +1,9 @@
 ---
 - name: Host smoke tests
-  hosts: all
+  # TODO This check should be enabled on jumpbox and jenkins
+  # Skip the check on the delegate host because the firewall allows
+  # localhost access and the check will fail.
+  hosts: "!jumpbox:!jenkins"
   tasks:
     - name: assert smtp port is closed
       wait_for:

--- a/ansible/smoke.yml
+++ b/ansible/smoke.yml
@@ -1,0 +1,138 @@
+---
+- name: Host smoke tests
+  hosts: all
+  tasks:
+    - name: assert smtp port is closed
+      wait_for:
+        host: "{{ ansible_fqdn }}"
+        port: 25
+        state: stopped  # closed
+        msg: smtp port expected to be closed
+        timeout: 10
+      delegate_to: localhost
+
+
+- name: www.data.gov cache smoke tests
+  hosts: all
+  tasks:
+    - name: assert main page is cached
+      vars:
+        url: https://www.data.gov/
+      block:
+        - name: prime the cache
+          uri:
+            url: "{{ url }}"
+            status_code: 200
+            follow_redirects: none
+        - name: wait for 10 seconds
+          pause:
+            seconds: 10
+        - name: check the cache
+          uri:
+            url: "{{ url }}"
+            status_code: 200
+            follow_redirects: none
+          register: second_response
+        - name: assert second request receives cached response
+          assert:
+            that: second_response.x_cache == "Hit from cloudfront"
+            fail_msg: |
+              Response looks like it was not cached when it should be:
+              {{ second_response | to_json }}
+      delegate_to: localhost
+      run_once: true
+
+    - name: assert TTL for 4xx is less than 10 seconds to prevent CPDoS
+      block:
+        - name: prime the cache
+          uri:
+            url: https://www.data.gov/four04?unique=1
+            status_code: 404
+            follow_redirects: none
+          register: first_response
+        - name: wait for 10 seconds
+          pause:
+            seconds: 10
+        - name: check the cache
+          uri:
+            url: https://www.data.gov/four04?unique=1
+            status_code: 404
+            follow_redirects: none
+          register: second_response
+        - name: debug first_response
+          debug:
+            msg: "first_response={{ first_response | to_json }}"
+          when: debug is defined
+        - name: assert not cached
+          assert:
+            that: second_response.x_cache != "Hit from cloudfront"
+            fail_msg: |
+              Response looks like it was cached when it shouldn't be:
+              {{ second_response | to_json }}
+      delegate_to: localhost
+      run_once: true
+
+
+- name: catalog.data.gov cache smoke tests
+  hosts: all
+  tasks:
+    - name: assert static assets are cached
+      # This test is a bit tricky because the URLs for most assets are
+      # generated at build time and change with each deploy. Use one that doesn't change.
+      vars:
+        url: https://catalog.data.gov/fanstatic/datagovtheme/images/favicon.ico
+      block:
+        - name: prime the cache
+          uri:
+            url: "{{ url }}"
+            status_code: 200
+            follow_redirects: none
+        - name: wait for 10 seconds
+          pause:
+            seconds: 10
+        - name: check the cache
+          uri:
+            url: "{{ url }}"
+            status_code: 200
+            follow_redirects: none
+          register: second_response
+        - name: assert second request receives cached response
+          assert:
+            that: second_response.x_cache == "Hit from cloudfront"
+            fail_msg: |
+              Response looks like it was not cached when it should be:
+              {{ second_response | to_json }}
+      delegate_to: localhost
+      run_once: true
+
+
+    - name: assert TTL for 4xx is less than 10 seconds to prevent CPDoS
+      block:
+        - name: prime the cache
+          uri:
+            url: https://catalog.data.gov/four04?unique=1
+            status_code: 404
+            follow_redirects: none
+          register: first_response
+        - name: wait for 10 seconds
+          pause:
+            seconds: 10
+        - name: check the cache
+          uri:
+            url: https://catalog.data.gov/four04?unique=1
+            status_code: 404
+            follow_redirects: none
+            return_content: true
+          register: second_response
+        - name: debug first_response
+          debug:
+            msg: "first_response={{ first_response | to_json }}"
+          when: debug is defined
+        - name: assert not cached
+          assert:
+            that: first_response.x_cache != "Hit from cloudfront"
+            fail_msg: |
+              Response looks like it was cached when it shouldn't be:
+              {{ second_response.content }}
+      delegate_to: localhost
+      run_once: true

--- a/ansible/smoke.yml
+++ b/ansible/smoke.yml
@@ -17,6 +17,7 @@
 
 - name: www.data.gov cache smoke tests
   hosts: all
+  gather_facts: false
   tasks:
     - name: assert main page is cached
       vars:
@@ -78,6 +79,7 @@
 
 - name: catalog.data.gov cache smoke tests
   hosts: all
+  gather_facts: false
   tasks:
     - name: assert static assets are cached
       # This test is a bit tricky because the URLs for most assets are


### PR DESCRIPTION
https://github.com/gsa/datagov-deploy/issues/1924

Adds a playbook to cover various smoke tests and checks once the platform has
been deployed.

Currently includes some port tests for postfix and some caching tests for
CloudFront.