### PR TITLE
[Hotfix] chmod to 644 so www-data can access export.map.json

### DIFF
--- a/ansible/roles/software/ckan/inventory/molecule/default/tests/test_default.py
+++ b/ansible/roles/software/ckan/inventory/molecule/default/tests/test_default.py
@@ -34,7 +34,9 @@ def test_apache2_sites(host):
 
 
 def test_export_map_json(host):
-    json = host.file('/usr/lib/ckan/src/ckanext-datajson/ckanext/datajson/export_map/export.map.json')
+    json = host.file("""/usr/lib/ckan/src/ckanext-datajson
+        /ckanext/datajson/export_map/export.map.json""")
+    ckan = host.file('/etc/apache2/sites-enabled/ckan.conf')
 
     assert json.exists
     assert json.user == 'root'

--- a/ansible/roles/software/ckan/inventory/molecule/default/tests/test_default.py
+++ b/ansible/roles/software/ckan/inventory/molecule/default/tests/test_default.py
@@ -33,6 +33,16 @@ def test_apache2_sites(host):
         'ErrorLog /var/log/inventory/datapusher.error.log')
 
 
+def test_export_map_json(host):
+    json = host.file('/usr/lib/ckan/src/ckanext-datajson/ckanext/datajson/export_map/export.map.json')
+
+    assert json.exists
+    assert json.user == 'root'
+    assert json.group == 'www-data'
+    assert json.mode == 0o640
+    assert ckan.contains('dataset_field_map')
+
+
 def test_apache2(host):
     apache2 = host.service('apache2')
 

--- a/ansible/roles/software/ckan/inventory/molecule/default/tests/test_default.py
+++ b/ansible/roles/software/ckan/inventory/molecule/default/tests/test_default.py
@@ -34,8 +34,8 @@ def test_apache2_sites(host):
 
 
 def test_export_map_json(host):
-    json = host.file('/usr/lib/ckan/src/ckanext-datajson/ckanext' \
-        '/datajson/export_map/export.map.json')
+    json = host.file('/usr/lib/ckan/src/ckanext-datajson/ckanext'
+                     '/datajson/export_map/export.map.json')
 
     assert json.exists
     assert json.user == 'root'

--- a/ansible/roles/software/ckan/inventory/molecule/default/tests/test_default.py
+++ b/ansible/roles/software/ckan/inventory/molecule/default/tests/test_default.py
@@ -34,15 +34,14 @@ def test_apache2_sites(host):
 
 
 def test_export_map_json(host):
-    json = host.file("""/usr/lib/ckan/src/ckanext-datajson
-        /ckanext/datajson/export_map/export.map.json""")
-    ckan = host.file('/etc/apache2/sites-enabled/ckan.conf')
+    json = host.file('/usr/lib/ckan/src/ckanext-datajson/ckanext' \
+        '/datajson/export_map/export.map.json')
 
     assert json.exists
     assert json.user == 'root'
     assert json.group == 'www-data'
-    assert json.mode == 0o640
-    assert ckan.contains('dataset_field_map')
+    assert json.mode == 0o644
+    assert json.contains('dataset_fields_map')
 
 
 def test_apache2(host):

--- a/ansible/roles/software/ckan/inventory/tasks/additional-tasks.yml
+++ b/ansible/roles/software/ckan/inventory/tasks/additional-tasks.yml
@@ -18,6 +18,9 @@
   copy:
     src: "{{ virtualenv }}/src/ckanext-datajson/ckanext/datajson/export_map/export.inventory.map.sample.json"
     dest: "{{ virtualenv }}/src/ckanext-datajson/ckanext/datajson/export_map/export.map.json"
+    owner: root
+    group: www-data
+    mode: '0644'
     remote_src: true
   notify: restart apache2
 


### PR DESCRIPTION
Fixed issue #2127 where end user couldn't download Redacted and Unredacted Inventory file from an organization on Inventory.data.gov. It gives file permission error:

`<type 'exceptions.IOError'> : plugin.py : 197 : [Errno 13] Permission denied: '/usr/lib/ckan-new/src/ckanext-datajson/ckanext/datajson/export_map/export.map.json'`
