### PR TITLE
Monit threshold to 82

### DIFF
--- a/ansible/group_vars/all/vars.yml
+++ b/ansible/group_vars/all/vars.yml
@@ -128,7 +128,7 @@ nrinfragent_config:
 
 
 # monit settings
-monit_apache2_mem_threshold: 83
+monit_apache2_mem_threshold: 82
 
 
 # Nginx


### PR DESCRIPTION
We have had 2 instances where our high memory alert has fired (over 90% for 5 minutes), and then monit has restarted service about 5-10 minutes later. Since the monit % threshold is not the same as new relic, we need to tweak so that it will restart before our new relic alert fires.