### PR TITLE
move admin hosts above readonly hosts

### DIFF
--- a/ansible/inventories/staging/hosts
+++ b/ansible/inventories/staging/hosts
@@ -50,9 +50,9 @@ catalogharvester2d.dev-ocsit.bsp.gsa.gov
 [catalog-next-worker-qa]
 
 [catalog-next-web:children]
+catalog-next-web-admin
 catalog-next-web-a
 catalog-next-web-b
-catalog-next-web-admin
 
 [catalog-next-web-a]
 catalogweb1d.dev-ocsit.bsp.gsa.gov


### PR DESCRIPTION
In rare occasions, if there are edits to database schema, letting playbook run first on admin site will eliminate the error we saw in [recent release 20200917](https://gsa-tts.slack.com/archives/C2N85536E/p1600284866210900?thread_ts=1600263480.199600&cid=C2N85536E) when read-only web host reported sql error when it tried to add index to read replica RDS. 