### PR TITLE
Bump wordpress for CRLF injection fix

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -70,7 +70,7 @@
   version: v1.2.0
 - name: gsa.datagov-deploy-wordpress
   src: https://github.com/GSA/datagov-deploy-wordpress.git
-  version: v1.0.6
+  version: v1.0.7
 - name: jnv.unattended-upgrades
   version: v1.8.0
 - name: jobscore.beats


### PR DESCRIPTION
https://github.com/gsa/datagov-deploy/issues/2148
https://hackerone.com/reports/952068

Includes https://github.com/GSA/datagov-deploy-wordpress/pull/17