### PR TITLE
 Add config needed for upstream ckanext-archiver

### DIFF
--- a/ansible/roles/software/ckan/catalog/ckan-app/templates/catalog-next/etc_ckan_production.ini.j2
+++ b/ansible/roles/software/ckan/catalog/ckan-app/templates/catalog-next/etc_ckan_production.ini.j2
@@ -238,6 +238,10 @@ ckanext.geodatagov.bureau_csv.url_default=https://resources.data.gov/schemas/dca
 ckanext.datagovtheme.use.archiver=false
 ckanext.datagovtheme.use.qa=false
 
+# Archiver Settings
+
+ckanext-archiver.cache_url_root={{ ckan_site_domain }}
+
 ## Logging configuration
 [loggers]
 keys = root, ckan, ckanext


### PR DESCRIPTION
ckanext-archiver now requires that the cache_url_root value be set in the base config https://github.com/ckan/ckanext-archiver#using-archiver