### PR TITLE
Revert "Add Solr "next" cores"

### DIFF
--- a/ansible/inventories/staging/group_vars/all/vars.yml
+++ b/ansible/inventories/staging/group_vars/all/vars.yml
@@ -161,6 +161,7 @@ inventory_next_ckan_s3_bucket_prefix: "{{ vault_inventory_next_s3_bucket_prefix 
 inventory_next_ckan_instance_secret: "{{ vault_inventory_next_ckan_instance_secret }}"
 inventory_next_ckan_instance_uuid: "{{ vault_inventory_next_ckan_instance_uuid }}"
 inventory_next_ckan_service_url: https://inventory-next-datagov.dev-ocsit.bsp.gsa.gov
+inventory_next_ckan_solr_host: datagov-solrm1d-v2.dev-ocsit.bsp.gsa.gov
 inventory_next_ckan_who_ini_secret: "{{ vault_inventory_next_ckan_who_ini_secret }}"
 inventory_next_ckan_redis_host: "redis1d.dev-ocsit.bsp.gsa.gov"
 inventory_next_ckan_redis_password: "{{ vault_inventory_next_ckan_redis_password }}"

--- a/ansible/inventories/staging/group_vars/all/vars.yml
+++ b/ansible/inventories/staging/group_vars/all/vars.yml
@@ -204,9 +204,7 @@ solr_java_packages:
   - openjdk-8-jdk
 solr_cores:
   - catalog
-  - catalog-next
   - inventory
-  - inventory-next
 solr_xms: 8192m
 solr_xmx: 8192m
 

--- a/ansible/inventories/staging/group_vars/inventory-next/vars.yml
+++ b/ansible/inventories/staging/group_vars/inventory-next/vars.yml
@@ -45,3 +45,6 @@ inventory_ckan_redis_url: redis://localhost:6379/0
 ckan_instance_secret: "{{ inventory_next_ckan_instance_secret }}"
 ckan_instance_uuid: "{{ inventory_next_ckan_instance_uuid }}"
 who_ini_secret: "{{ inventory_next_ckan_who_ini_secret }}"
+
+# solr
+inventory_ckan_solr_host: "{{ inventory_next_ckan_solr_host }}"

--- a/ansible/inventories/staging/group_vars/solr-next/vars.yml
+++ b/ansible/inventories/staging/group_vars/solr-next/vars.yml
@@ -4,5 +4,6 @@ datagov_service: solr
 solr_master_server: datagov-solrm1d-v2.dev-ocsit.bsp.gsa.gov
 solr_cores:
   - catalog-next
+  - inventory-next
 
 trendmicro_policy_id: "{{ trendmicro_policy_id_app }}"


### PR DESCRIPTION
Reverts GSA/datagov-deploy#2203
Output of debug.yml (is what we expected):
```
ansible-playbook ansible/debug.yml -i ansible/inventories/staging -e debug_variable=inventory_ckan_solr_host --limit inventory-1d.dev-ocsit.bsp.gsa.gov
[WARNING]: Invalid characters were found in group names but not replaced, use -vvvv to see details


PLAY [Debug] ****************************************************************************************************************************************

TASK [debug variable] *******************************************************************************************************************************
ok: [inventory-1d.dev-ocsit.bsp.gsa.gov -> localhost] => {
    "msg": "inventory_ckan_solr_host=datagov-solrm1d-v2.dev-ocsit.bsp.gsa.gov"
}
```