### PR TITLE
Point S3 data to a new folder

### DIFF
--- a/ansible/roles/software/ckan/catalog/ckan-app/templates/catalog-next/etc_ckan_production.ini.j2
+++ b/ansible/roles/software/ckan/catalog/ckan-app/templates/catalog-next/etc_ckan_production.ini.j2
@@ -233,6 +233,10 @@ googleanalytics.ids = UA-1010101-1 UA-1010101-2
 ckanext.geodatagov.bureau_csv.url=https://resources.data.gov/schemas/dcat-us/v1.1/omb_bureau_codes.csv
 ckanext.geodatagov.bureau_csv.url_default=https://resources.data.gov/schemas/dcat-us/v1.1/omb_bureau_codes.csv
 
+ckanext.geodatagov.metrics_csv.aws_storage_path = gsa/catalog-next/metrics/
+ckanext.geodatagov.s3sitemap.aws_storage_path = gsa/catalog-next/sitemap/
+ckanext.geodatagov.jsonlexport.aws_storage_path = gsa/catalog-next/jsonl/
+
 # DataGovTheme settings
 
 ckanext.datagovtheme.use.archiver=false


### PR DESCRIPTION
Related to [multi#447](https://github.com/GSA/datagov-ckan-multi/issues/447)
and [PR datagov-catalog#15](https://github.com/GSA/ckanext-datagovcatalog/pull/15/files)

This PR:
 - Point S3 data to a new `catalog-next` s3 folder to aviod old vs new catalog data collision
 - Point the new sitemap to this new folder