### PR TITLE
Add next urls to be ServerAlias

### DIFF
--- a/ansible/inventories/production/group_vars/all/vars.yml
+++ b/ansible/inventories/production/group_vars/all/vars.yml
@@ -1,6 +1,5 @@
 ---
 # catalog
-catalog_ckan_admin_service_url: https://admin-catalog.data.gov
 catalog_ckan_app_version: master
 catalog_ckan_archiver_process_count: 3
 catalog_ckan_db_host: "{{ vault_catalog_ckan_db_host }}"
@@ -16,7 +15,8 @@ catalog_ckan_redis_host: catalog-harvester1p.prod-ocsit.bsp.gsa.gov
 catalog_ckan_redis_password: "{{ redis_password }}"
 catalog_ckan_fgdc2iso_host: catalog-fgdc2iso1p.prod-ocsit.bsp.gsa.gov
 catalog_ckan_saml2_enabled: true
-catalog_ckan_service_url: https://catalog.data.gov
+catalog_ckan_service_url: https://{{ catalog_host_public }}
+catalog_ckan_admin_service_url: https://{{ catalog_host_admin }}
 catalog_ckan_solr_port: "8983"
 catalog_ckan_solr_host: datagov-solr1p.prod-ocsit.bsp.gsa.gov
 catalog_ckan_wsgi_processes: 6
@@ -157,6 +157,10 @@ catalog_url_public: https://{{ catalog_host_public }}
 catalog_url_admin: https://{{ catalog_host_admin }}
 
 ckan_site_domain: "{{ catalog_host_public }}"
+
+# next public urls
+catalog_host_public_next: catalog-next.data.gov
+catalog_host_admin_next: admin-catalog-next.data.gov
 
 
 # s3 bucket

--- a/ansible/inventories/sandbox/group_vars/all/vars.yml
+++ b/ansible/inventories/sandbox/group_vars/all/vars.yml
@@ -213,6 +213,10 @@ catalog_url_admin: https://{{ catalog_host_admin }}
 
 ckan_site_domain: "{{ catalog_host_public }}"
 
+# next public urls
+catalog_host_public_next: catalog-next.sandbox.datagov.us
+catalog_host_admin_next: catalog-next.sandbox.datagov.us
+
 
 # s3 bucket
 catalog_bucket_name: "{{ vault_catalog_bucket_name }}"

--- a/ansible/inventories/sandbox/group_vars/catalog-next/vars.yml
+++ b/ansible/inventories/sandbox/group_vars/catalog-next/vars.yml
@@ -1,6 +1,6 @@
 ---
-catalog_ckan_service_url: https://catalog-next.sandbox.datagov.us
-ckan_site_domain: https://catalog-next.sandbox.datagov.us
+catalog_ckan_service_url: https://{{ catalog_host_public_next }}
+ckan_site_domain: https://{{ catalog_host_public_next }}
 
 catalog_ckan_db_host: "{{ catalog_next_postgresql_login_host }}"
 catalog_ckan_db_name: "{{ catalog_next_ckan_db_name }}"

--- a/ansible/inventories/staging/group_vars/all/vars.yml
+++ b/ansible/inventories/staging/group_vars/all/vars.yml
@@ -16,8 +16,8 @@ catalog_ckan_redis_host: catalog-harvester1d.dev-ocsit.bsp.gsa.gov
 catalog_ckan_redis_password: "{{ redis_password }}"
 catalog_ckan_fgdc2iso_host: catalog-fgdc2iso1d.dev-ocsit.bsp.gsa.gov
 catalog_ckan_saml2_enabled: true
-catalog_ckan_service_url: https://catalog-datagov.dev-ocsit.bsp.gsa.gov
-catalog_ckan_admin_service_url: https://admin-catalog-datagov.dev-ocsit.bsp.gsa.gov
+catalog_ckan_service_url: https://{{ catalog_host_public }}
+catalog_ckan_admin_service_url: https://{{ catalog_host_admin }}
 catalog_ckan_solr_host: datagov-solr1d.dev-ocsit.bsp.gsa.gov
 catalog_ckan_solr_port: "8983"
 # read-only database variables
@@ -42,8 +42,6 @@ catalog_next_ckan_production_ini_template: catalog-next/etc_ckan_production.ini.
 catalog_next_ckan_redis_host: redis1d.dev-ocsit.bsp.gsa.gov
 catalog_next_ckan_redis_password: "{{ vault_catalog_next_ckan_redis_password }}"
 catalog_next_ckan_redis_url: redis://:{{ catalog_next_ckan_redis_password }}@{{ catalog_next_ckan_redis_host }}:6379/0
-catalog_next_ckan_service_url: https://catalog-next-datagov.dev-ocsit.bsp.gsa.gov
-catalog_next_ckan_admin_service_url: https://admin-catalog-next-datagov.dev-ocsit.bsp.gsa.gov
 catalog_next_ckan_solr_a_host: datagov-solr1d-v2.dev-ocsit.bsp.gsa.gov
 catalog_next_ckan_solr_b_host: datagov-solr2d-v2.dev-ocsit.bsp.gsa.gov
 catalog_next_ckan_solr_primary_host: datagov-solrm1d-v2.dev-ocsit.bsp.gsa.gov
@@ -195,6 +193,10 @@ catalog_url_public: https://{{ catalog_host_public }}
 catalog_url_admin: https://{{ catalog_host_admin }}
 
 ckan_site_domain: "{{ catalog_host_public }}"
+
+# next public urls
+catalog_host_public_next: catalog-next-datagov.dev-ocsit.bsp.gsa.gov
+catalog_host_admin_next: admin-catalog-next-datagov.dev-ocsit.bsp.gsa.gov
 
 
 # Redis

--- a/ansible/inventories/staging/group_vars/catalog-next/vars.yml
+++ b/ansible/inventories/staging/group_vars/catalog-next/vars.yml
@@ -12,8 +12,8 @@ catalog_ckan_readwrite_configuration: readonly
 catalog_ckan_redis_host: "{{ catalog_next_ckan_redis_host }}"
 catalog_ckan_redis_password: "{{ catalog_next_ckan_redis_password }}"
 catalog_ckan_redis_url: "{{ catalog_next_ckan_redis_url }}"
-catalog_ckan_service_url: "{{ catalog_next_ckan_service_url }}"
-catalog_ckan_admin_service_url: "{{ catalog_next_ckan_admin_service_url }}"
+catalog_ckan_service_url: https://{{ catalog_host_public_next }}
+catalog_ckan_admin_service_url: https://{{ catalog_host_admin_next }}
 catalog_ckan_saml2_enabled: false
 catalog_ckan_solr_host: "{{ catalog_next_ckan_solr_a_host }}"  # default. this is probably overridden in other groups/host vars
 catalog_ckan_who_ini_secret: "{{ catalog_next_ckan_who_ini_secret }}"
@@ -39,5 +39,5 @@ saml2_site_url: https://admin-catalog-next-datagov.dev-ocsit.bsp.gsa.gov/
 # Token for working with the Google Analytics API
 token_dat: "{{ catalog_next_ckan_token_dat }}"
 
-url_readonly: "{{ catalog_next_ckan_service_url }}"
-url_writable: "{{ catalog_next_ckan_admin_service_url }}"
+url_readonly: https://{{ catalog_host_public_next }}
+url_writable: https://{{ catalog_host_admin_next }}

--- a/ansible/roles/software/ckan/catalog/ckan-app/defaults/main.yml
+++ b/ansible/roles/software/ckan/catalog/ckan-app/defaults/main.yml
@@ -55,6 +55,8 @@ ckan_create_user_via_web: false
 # used in apache conf to whitelist allowed hostname
 catalog_host_public: catalog.localdomain.local
 catalog_host_admin: admin-catalog.localdomain.local
+catalog_host_public_next: catalog-next.localdomain.local
+catalog_host_admin_next: admin-catalog-next.localdomain.local
 
 # provide some default values to be overwritten later by group vars and host vars...
 project_source_rollback_path: /usr/lib/ckan-rollback

--- a/ansible/roles/software/ckan/catalog/ckan-app/defaults/main.yml
+++ b/ansible/roles/software/ckan/catalog/ckan-app/defaults/main.yml
@@ -52,6 +52,10 @@ app_repo_branch: master
 ckan_site_domain: "http://127.0.0.1"
 ckan_create_user_via_web: false
 
+# used in apache conf to whitelist allowed hostname
+catalog_host_public: catalog.localdomain.local
+catalog_host_admin: admin-catalog.localdomain.local
+
 # provide some default values to be overwritten later by group vars and host vars...
 project_source_rollback_path: /usr/lib/ckan-rollback
 project_source_new_code_path: /usr/lib/ckan-new

--- a/ansible/roles/software/ckan/catalog/ckan-app/molecule/catalog-next/tests/test_default.py
+++ b/ansible/roles/software/ckan/catalog/ckan-app/molecule/catalog-next/tests/test_default.py
@@ -8,6 +8,8 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 virtualenv_path = '/usr/lib/ckan'
+catalog_host_public = 'catalog.localdomain.local'
+catalog_host_public_next = 'catalog-next.localdomain.local'
 
 
 def test_var_lib_ckan(host):
@@ -107,3 +109,7 @@ def test_apache_site(host):
     assert f.group == 'www-data'
     assert f.mode == 0o644
     assert f.contains('ErrorLog /var/log/ckan/ckan.error.log')
+
+    # catalog domain ServerName, catalog-next in ServerAlias
+    assert f.contains('ServerName %s' % catalog_host_public)
+    assert f.contains('ServerAlias %s' % catalog_host_public_next)

--- a/ansible/roles/software/ckan/catalog/ckan-app/molecule/readwrite/tests/test_default.py
+++ b/ansible/roles/software/ckan/catalog/ckan-app/molecule/readwrite/tests/test_default.py
@@ -9,6 +9,8 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 virtualenv_path = '/usr/lib/ckan'
 readonly_url = 'https://readonly.ckan'
+catalog_host_public = 'catalog.localdomain.local'
+catalog_host_admin = 'admin-catalog.localdomain.local'
 
 
 def test_var_lib_ckan(host):
@@ -107,6 +109,12 @@ def test_apache_site(host):
     assert f.group == 'www-data'
     assert f.mode == 0o644
     assert f.contains('ErrorLog /var/log/ckan/ckan.error.log')
+
+    # In readwrite configuration, ServerName is admin site, not
+    # public site.
+    assert f.contains('Redirect 404 /')
+    assert f.contains('ServerName %s' % catalog_host_admin)
+    assert not f.contains('ServerName %s' % catalog_host_public)
 
     # In readwrite configuration, redirect unauthenticated requests to the
     # readonly url.

--- a/ansible/roles/software/ckan/catalog/ckan-app/templates/etc_apache2_sites-enabled_ckan.conf.j2
+++ b/ansible/roles/software/ckan/catalog/ckan-app/templates/etc_apache2_sites-enabled_ckan.conf.j2
@@ -4,7 +4,24 @@ SSLEngine on
 </VirtualHost>
 
 <VirtualHost 0.0.0.0:80>
-    ServerName ckan
+  ServerName ckan
+  Redirect 404 /
+</VirtualHost>
+
+<VirtualHost 0.0.0.0:80>
+{% if catalog_ckan_readwrite_configuration == 'readwrite' %}
+    ServerName {{ catalog_host_admin }}
+  {% if ckan_catalog_next == true %}
+    ServerAlias {{ catalog_host_admin_next }}
+  {% endif %}
+{% else %}
+    ServerName {{ catalog_host_public }}
+  {% if ckan_catalog_next == true %}
+    ServerAlias {{ catalog_host_public_next }}
+  {% endif %}
+{% endif %}
+    ServerAlias localhost
+    ServerAlias {{ ansible_fqdn }}
 
     # CSW endpoints provided by pycsw
     # based on request URI


### PR DESCRIPTION
Redo https://github.com/GSA/datagov-deploy/pull/2258. 
This time catalog-next hosts are added as ServerAlias.
for https://github.com/GSA/datagov-deploy/issues/1491