### PR TITLE
Remove user/group from supervisord config for catalog

### DIFF
--- a/ansible/roles/software/ckan/catalog/ckan-app/templates/supervisord_gunicorn.conf.j2
+++ b/ansible/roles/software/ckan/catalog/ckan-app/templates/supervisord_gunicorn.conf.j2
@@ -1,8 +1,6 @@
 [program:catalog-web]
 command={{ project_source_new_code_path }}/bin/gunicorn --worker-class gevent --paste /etc/ckan/production.ini -b localhost:5000 --proxy-allow-from="127.0.0.1"
 directory={{ project_source_new_code_path }}
-user=www-data
-group=www-data
 stdout_logfile={{ catalog_gunicorn_error_log }}
 autostart=true
 autorestart=true


### PR DESCRIPTION
Otherwise, we get permission denied:

```
  File "/usr/lib/ckan-new/src/ckan/ckan/lib/i18n.py", line 348, in _build_js_translation
    with open(dest_filename, u'w') as f:
IOError: [Errno 13] Permission denied: u'/usr/lib/ckan-new/src/ckan/ckan/public/base/i18n/am.js'
```