### PR TITLE
Bump datagov-deploy-jumpbox

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -58,7 +58,7 @@
   version: v1.0.0
 - name: gsa.datagov-deploy-jumpbox
   src: https://github.com/GSA/datagov-deploy-jumpbox
-  version: v2.1.1
+  version: v2.1.2
 - name: gsa.datagov-deploy-pycsw
   src: https://github.com/GSA/datagov-deploy-pycsw
   version: v1.0.5


### PR DESCRIPTION
Pickup change to datagov-deploy-jumpbox so that the ubuntu user is added to the
operators group and simplifies the Ansible vault configuration via /etc/datagov.