### PR TITLE
Add the clean_harvest_log task to catalog-next

### DIFF
--- a/ansible/roles/software/ckan/catalog/ckan-app/files/etc/cron.d/ckan_misc_worker
+++ b/ansible/roles/software/ckan/catalog/ckan-app/files/etc/cron.d/ckan_misc_worker
@@ -1,6 +1,7 @@
 @monthly root supervisorctl start ckan-metrics-csv > /dev/null
 
 #1 1 * * * root supervisorctl start ckan-clean-deleted
+#30 2 * * * root supervisorctl start ckan-clean-harvest-logs
 #1 3 * * * root supervisorctl start ckan-tracking-update > /dev/null
 #30 23 * * * root supervisorctl start qa-update-sel:*
 #30 7 * * * root supervisorctl stop qa-update-sel:*

--- a/ansible/roles/software/ckan/catalog/ckan-app/templates/catalog-next/etc_ckan_production.ini.j2
+++ b/ansible/roles/software/ckan/catalog/ckan-app/templates/catalog-next/etc_ckan_production.ini.j2
@@ -200,6 +200,9 @@ set debug = False
 # Mark as finished Jobs in 'Running' status after x minutes (1440 min = 24 hours)
 ckan.harvest.timeout = 1440
 
+# define the time frame in days to clean the harvest logs
+ckan.harvest.log_timeframe = 180
+
 ckan.harvest.mq.type = redis
 ckanext.harvest.email = on
 ckan.harvest.status_mail.all=True

--- a/ansible/roles/software/ckan/catalog/ckan-app/templates/supervisord_misc_worker.conf.j2
+++ b/ansible/roles/software/ckan/catalog/ckan-app/templates/supervisord_misc_worker.conf.j2
@@ -5,6 +5,13 @@ redirect_stderr=true
 autostart=false
 autorestart=false
 
+[program:ckan-clean-harvest-logs]
+command=ckan --plugin=ckanext-harvest harvester clean_harvest_log -c /etc/ckan/production.ini
+stdout_logfile=/var/log/ckan/clean_harvest_log.log
+redirect_stderr=true
+autostart=false
+autorestart=false
+
 [program:ckan-combine-feeds]
 command=ckan --plugin=ckanext-geodatagov geodatagov combine-feeds
 stdout_logfile=/var/log/ckan/combine-feeds.log

--- a/ansible/roles/software/ckan/catalog/ckan-app/templates/supervisord_misc_worker.conf.j2
+++ b/ansible/roles/software/ckan/catalog/ckan-app/templates/supervisord_misc_worker.conf.j2
@@ -6,7 +6,7 @@ autostart=false
 autorestart=false
 
 [program:ckan-clean-harvest-logs]
-command=ckan --plugin=ckanext-harvest harvester clean_harvest_log -c /etc/ckan/production.ini
+command=ckan --plugin=ckanext-harvest harvester clean_harvest_log
 stdout_logfile=/var/log/ckan/clean_harvest_log.log
 redirect_stderr=true
 autostart=false


### PR DESCRIPTION
Related to [Multi#453](https://github.com/GSA/datagov-ckan-multi/issues/453)

This PR:
 - Add the setting to define the timeframe in days ti clean harvest logs
 - Create a new supervisor task to clean these logs
 - Add this task to cron (commented)

Pending:
 - Define a way to run this task only for catalog-next environments