### PR TITLE
Add cron job to clean harvets logs in worker-next

### DIFF
--- a/ansible/roles/software/ckan/catalog/ckan-app/defaults/main.yml
+++ b/ansible/roles/software/ckan/catalog/ckan-app/defaults/main.yml
@@ -40,6 +40,7 @@ catalog_ckan_plugins_default:
 catalog_ckan_python_home: /usr
 catalog_ckan_saml2_enabled: false
 catalog_harvest_enable_harvest_report: false
+catalog_enable_clean_harvest_logs: false
 catalog_log_dir: /var/log/ckan
 catalog_gunicorn_error_log: "{{ catalog_log_dir }}/gunicorn.log"
 

--- a/ansible/roles/software/ckan/catalog/ckan-app/molecule/worker-next/playbook.yml
+++ b/ansible/roles/software/ckan/catalog/ckan-app/molecule/worker-next/playbook.yml
@@ -8,3 +8,4 @@
         catalog_ckan_email_from: no-reply@data.gov
         catalog_ckan_worker_type: main_worker
         catalog_harvest_enable_harvest_report: true
+        catalog_enable_clean_harvest_logs: true

--- a/ansible/roles/software/ckan/catalog/ckan-app/tasks/worker.yml
+++ b/ansible/roles/software/ckan/catalog/ckan-app/tasks/worker.yml
@@ -36,7 +36,7 @@
     minute: "30"
     hour: "2"
     user: root
-    disabled: "{{ not crons_enabled or not catalog_enable_clean_harvest_logs }}"
+    disabled: "{{ not catalog_enable_clean_harvest_logs }}"
     state: present
   tags: ['cron']
 

--- a/ansible/roles/software/ckan/catalog/ckan-app/tasks/worker.yml
+++ b/ansible/roles/software/ckan/catalog/ckan-app/tasks/worker.yml
@@ -36,8 +36,8 @@
     minute: "30"
     hour: "2"
     user: root
-    disabled: "{{ not crons_enabled }}"
-    state: {{ catalog_enable_clean_harvest_logs | ternary('present', 'absent') }}
+    disabled: "{{ not crons_enabled or not catalog_enable_clean_harvest_logs }}"
+    state: present
   tags: ['cron']
 
 - name: install worker cron jobs

--- a/ansible/roles/software/ckan/catalog/ckan-app/tasks/worker.yml
+++ b/ansible/roles/software/ckan/catalog/ckan-app/tasks/worker.yml
@@ -28,6 +28,18 @@
     - usr/bin/celery-mem-check.sh
   when: catalog_ckan_worker_type == 'qa_worker'
 
+- name: schedule ckan-clean-harvest-logs cron
+  cron:
+    name: "clean harvest logs in db"
+    cron_file: ckan
+    job: supervisorctl start ckan-clean-harvest-logs > /dev/null
+    minute: "30"
+    hour: "2"
+    user: root
+    disabled: "{{ not crons_enabled }}"
+    state: {{ catalog_enable_clean_harvest_logs | ternary('present', 'absent') }}
+  tags: ['cron']
+
 - name: install worker cron jobs
   copy: src=etc/cron.d/ckan_{{ catalog_ckan_worker_type }} dest=/etc/cron.d/ckan mode=0644 owner=root group=root
   tags: ['cron']


### PR DESCRIPTION
Related to [Multi#453](https://github.com/GSA/datagov-ckan-multi/issues/453)

Activate the `ckan-clean-harvest-logs` task for worker-next