### PR TITLE
Attempt to install pycsw in sandbox-next

### DIFF
--- a/ansible/inventories/sandbox/hosts
+++ b/ansible/inventories/sandbox/hosts
@@ -59,3 +59,15 @@ jumpbox
 solr
 jenkins
 wordpress-web
+
+[pycsw-web:children]
+pycsw-web-v2
+
+[pycsw-web-v2:children]
+catalog-next
+
+[pycsw-worker:children]
+pycsw-worker-v2
+
+[pycsw-worker-v2]
+catalog-harvester-next1tf.internal.sandbox.datagov.us

--- a/ansible/pycsw.yml
+++ b/ansible/pycsw.yml
@@ -1,6 +1,6 @@
 ---
 - name: Set the deploy version
-  hosts: pycsw-web,pycsw-worker,!v2
+  hosts: pycsw-web,pycsw-worker
   tasks:
     - name: Set deploy version
       set_fact:
@@ -9,7 +9,7 @@
   tags: always
 
 - name: CSW web
-  hosts: pycsw-web,!v2
+  hosts: pycsw-web
   serial: "{{ datagov_serial | default(1) }}"
   roles:
     - role: gsa.datagov-deploy-pycsw
@@ -68,7 +68,7 @@
 
 
 - name: CSW worker
-  hosts: pycsw-worker,!v2
+  hosts: pycsw-worker
   roles:
     - role: gsa.datagov-deploy-pycsw
       pycsw_role: worker
@@ -77,7 +77,7 @@
 
 
 - name: Service-level smoke tests
-  hosts: pycsw-web,!v2
+  hosts: pycsw-web
   tags:
     - smoke
   tasks:


### PR DESCRIPTION
Related to [Multi#306](https://github.com/GSA/datagov-ckan-multi/issues/306)

This PR allow pycsw to be installed in the sandbox for catalog-next