### PR TITLE
Disable CDN smoke tests in sandbox and staging

### DIFF
--- a/ansible/inventories/sandbox/group_vars/all/vars.yml
+++ b/ansible/inventories/sandbox/group_vars/all/vars.yml
@@ -295,6 +295,10 @@ secops_user: "{{ vault_secops_user }}"
 secops_user_public_key: "{{ vault_secops_user_public_key }}"
 
 
+# smoke tests
+smoke_enable_cdn_checks: false
+
+
 # solr
 solr_master_server: datagov-solr1tf.internal.{{ datagov_sandbox_env }}.datagov.us
 solr_java_packages:

--- a/ansible/inventories/staging/group_vars/all/vars.yml
+++ b/ansible/inventories/staging/group_vars/all/vars.yml
@@ -262,6 +262,11 @@ saml_idp_cert_fprint: "7A43DACB95D67FB6A804FD37C8A7DCA5B0384939"
 saml2_sp_public_certificate: "{{ vault_saml2_sp_public_certificate }}"
 saml2_sp_private_key: "{{ vault_saml2_sp_private_key }}"
 
+
+# smoke tests
+smoke_enable_cdn_checks: false
+
+
 # td-agent
 elasticsearch_endpoint: "{{ vault_elasticsearch_endpoint }}"
 bsp_elasticsearch_endpoint: "{{ vault_bsp_elasticsearch_endpoint }}"

--- a/ansible/smoke.yml
+++ b/ansible/smoke.yml
@@ -47,6 +47,7 @@
       delegate_to: localhost
       become: false
       run_once: true
+      when: smoke_enable_cdn_checks | default(True)
 
     - name: assert TTL for 4xx is less than 10 seconds to prevent CPDoS
       block:
@@ -78,6 +79,7 @@
       delegate_to: localhost
       become: false
       run_once: true
+      when: smoke_enable_cdn_checks | default(True)
 
 
 - name: catalog.data.gov cache smoke tests
@@ -113,6 +115,7 @@
       delegate_to: localhost
       become: false
       run_once: true
+      when: smoke_enable_cdn_checks | default(True)
 
 
     - name: assert TTL for 4xx is less than 10 seconds to prevent CPDoS
@@ -146,3 +149,4 @@
       delegate_to: localhost
       become: false
       run_once: true
+      when: smoke_enable_cdn_checks | default(True)


### PR DESCRIPTION
https://github.com/GSA/datagov-deploy/issues/2350

Avoid blocking builds on sandbox in case production is down.

https://ci.sandbox.datagov.us/blue/organizations/jenkins/deploy-ci-platform/detail/deploy-ci-platform/276/pipeline/
