### PR TITLE
[inventory] update supervisor handler

### DIFF
--- a/ansible/roles/software/ckan/inventory/handlers/main.yml
+++ b/ansible/roles/software/ckan/inventory/handlers/main.yml
@@ -3,8 +3,11 @@
   service: name=apache2 state=restarted
   when: datagov_in_service
 
-- name: reload supervisor
-  command: supervisorctl reload
+- name: restart supervisor
+  service: name=supervisor state=restarted
+
+- name: restart ckan
+  command: supervisorctl restart ckan
   when: datagov_in_service
   tags:
     - skip_ansible_lint

--- a/ansible/roles/software/ckan/inventory/handlers/main.yml
+++ b/ansible/roles/software/ckan/inventory/handlers/main.yml
@@ -12,6 +12,6 @@
   command: supervisorctl restart ckan
   when:
     - datagov_in_service
-    - inventory-next
+    - inventory_next
   tags:
     - skip_ansible_lint

--- a/ansible/roles/software/ckan/inventory/handlers/main.yml
+++ b/ansible/roles/software/ckan/inventory/handlers/main.yml
@@ -3,9 +3,6 @@
   service: name=apache2 state=restarted
   when: datagov_in_service
 
-- name: restart supervisor
-  service: name=supervisor state=restarted
-
 - name: reread supervisor
   command: supervisorctl reread
 

--- a/ansible/roles/software/ckan/inventory/handlers/main.yml
+++ b/ansible/roles/software/ckan/inventory/handlers/main.yml
@@ -8,7 +8,7 @@
 
 - name: restart ckan
   command: supervisorctl restart ckan
-  when: 
+  when:
     - datagov_in_service
     - inventory-next
   tags:

--- a/ansible/roles/software/ckan/inventory/handlers/main.yml
+++ b/ansible/roles/software/ckan/inventory/handlers/main.yml
@@ -6,6 +6,9 @@
 - name: restart supervisor
   service: name=supervisor state=restarted
 
+- name: reread supervisor
+  command: supervisorctl reread
+
 - name: restart ckan
   command: supervisorctl restart ckan
   when:

--- a/ansible/roles/software/ckan/inventory/handlers/main.yml
+++ b/ansible/roles/software/ckan/inventory/handlers/main.yml
@@ -10,8 +10,6 @@
 
 - name: restart ckan
   command: supervisorctl restart ckan
-  when:
-    - datagov_in_service
-    - inventory_next
+  when: datagov_in_service
   tags:
     - skip_ansible_lint

--- a/ansible/roles/software/ckan/inventory/handlers/main.yml
+++ b/ansible/roles/software/ckan/inventory/handlers/main.yml
@@ -8,6 +8,8 @@
 
 - name: restart ckan
   command: supervisorctl restart ckan
-  when: datagov_in_service
+  when: 
+    - datagov_in_service
+    - inventory-next
   tags:
     - skip_ansible_lint

--- a/ansible/roles/software/ckan/inventory/handlers/main.yml
+++ b/ansible/roles/software/ckan/inventory/handlers/main.yml
@@ -5,6 +5,8 @@
 
 - name: reread supervisor
   command: supervisorctl reread
+  tags:
+    - skip_ansible_lint
 
 - name: restart ckan
   command: supervisorctl restart ckan

--- a/ansible/roles/software/ckan/inventory/handlers/main.yml
+++ b/ansible/roles/software/ckan/inventory/handlers/main.yml
@@ -3,8 +3,8 @@
   service: name=apache2 state=restarted
   when: datagov_in_service
 
-- name: reread supervisor
-  command: supervisorctl reread
+- name: reload supervisor
+  command: supervisorctl reread && supervisorctl update
   tags:
     - skip_ansible_lint
 

--- a/ansible/roles/software/ckan/inventory/molecule/default/tests/test_default.py
+++ b/ansible/roles/software/ckan/inventory/molecule/default/tests/test_default.py
@@ -80,6 +80,6 @@ def test_beaker_cache_cleanup(host):
         '/usr/local/bin/beaker-cache-cleanup.sh')
 
 
-def test_gunicorn_web_app(host):
+def test_ckan_process(host):
     supervisor_output = host.check_output('supervisorctl status')
-    assert re.search(r'gunicorn-web-app +RUNNING', supervisor_output)
+    assert re.search(r'ckan +RUNNING', supervisor_output)

--- a/ansible/roles/software/ckan/inventory/molecule/inventory-next/tests/test_default.py
+++ b/ansible/roles/software/ckan/inventory/molecule/inventory-next/tests/test_default.py
@@ -1,6 +1,6 @@
 
 
-def test_gunicorn_datapusher(host):
+def test_wsgi_datapusher(host):
     apache = host.file('/etc/apache2/sites-enabled/datapusher.conf')
 
     assert apache.exists

--- a/ansible/roles/software/ckan/inventory/tasks/additional-tasks.yml
+++ b/ansible/roles/software/ckan/inventory/tasks/additional-tasks.yml
@@ -47,7 +47,7 @@
     mode: "0644"
     owner: root
     group: root
-  notify: restart supervisor
+  notify: reread supervisor
 
 - name: schedule beaker-cache-cleanup cron
   cron:

--- a/ansible/roles/software/ckan/inventory/tasks/additional-tasks.yml
+++ b/ansible/roles/software/ckan/inventory/tasks/additional-tasks.yml
@@ -5,6 +5,8 @@
     build_pkg_repo: "https://github.com/GSA/ckanext-s3filestore"
     build_pkg_requirements: "requirements.txt"
   tags: ['s3filestore']
+  notify:
+    - restart ckan
 
 - name: copy datajson export map
   copy:
@@ -14,7 +16,6 @@
     group: www-data
     mode: '0644'
     remote_src: true
-  notify: restart apache2
 
 - name: install inventory db init script
   copy: src=inventory-db-init.py dest=/usr/local/bin/inventory-db-init.py owner=root group=root mode=0755
@@ -39,12 +40,6 @@
     owner: root
     group: root
 
-# need this manual start to pass molecule test?
-- name: start supervisor
-  service:
-    name: supervisor
-    state: started
-
 - name: copy supervisord config
   copy:
     src: beaker-cache-cleanup.conf
@@ -52,11 +47,8 @@
     mode: "0644"
     owner: root
     group: root
-
-- name: add beaker-cache-cleanup program
-  supervisorctl:
-    name: beaker-cache-cleanup
-    state: present
+  notify:
+    - restart supervisor
 
 - name: schedule beaker-cache-cleanup cron
   cron:

--- a/ansible/roles/software/ckan/inventory/tasks/additional-tasks.yml
+++ b/ansible/roles/software/ckan/inventory/tasks/additional-tasks.yml
@@ -5,8 +5,6 @@
     build_pkg_repo: "https://github.com/GSA/ckanext-s3filestore"
     build_pkg_requirements: "requirements.txt"
   tags: ['s3filestore']
-  notify:
-    - restart ckan
 
 - name: copy datajson export map
   copy:
@@ -16,6 +14,7 @@
     group: www-data
     mode: '0644'
     remote_src: true
+  notify: restart ckan
 
 - name: install inventory db init script
   copy: src=inventory-db-init.py dest=/usr/local/bin/inventory-db-init.py owner=root group=root mode=0755
@@ -26,6 +25,7 @@
     - inventory_next
     - db_is_setup
   become: true
+  notify: restart ckan
 
 - name: install beaker cache cleanup script
   template: src=beaker-cache-cleanup.sh.j2 dest=/usr/local/bin/beaker-cache-cleanup.sh owner=root group=root mode=0755
@@ -47,8 +47,7 @@
     mode: "0644"
     owner: root
     group: root
-  notify:
-    - restart supervisor
+  notify: restart supervisor
 
 - name: schedule beaker-cache-cleanup cron
   cron:

--- a/ansible/roles/software/ckan/inventory/tasks/additional-tasks.yml
+++ b/ansible/roles/software/ckan/inventory/tasks/additional-tasks.yml
@@ -47,7 +47,7 @@
     mode: "0644"
     owner: root
     group: root
-  notify: reread supervisor
+  notify: reload supervisor
 
 - name: schedule beaker-cache-cleanup cron
   cron:

--- a/ansible/roles/software/ckan/inventory/tasks/build-pkgs.yml
+++ b/ansible/roles/software/ckan/inventory/tasks/build-pkgs.yml
@@ -6,7 +6,6 @@
     version: "{{ build_pkg_branch | default('master') }}"
     force: yes
     umask: "0022"
-  notify: restart apache2
 
 - name: install requirements for pkg
   pip:
@@ -15,10 +14,8 @@
     virtualenv_python: "{{ inventory_python_home }}/bin/python"
     umask: "0022"
   when: build_pkg_requirements is defined
-  notify: restart apache2
 
 - name: run setup
   command: chdir={{ virtualenv }}/src/{{ build_pkg_name }} {{ virtualenv }}/bin/python setup.py develop
   tags:
     - skip_ansible_lint
-  notify: restart apache2

--- a/ansible/roles/software/ckan/inventory/tasks/datapusher-classic.yml
+++ b/ansible/roles/software/ckan/inventory/tasks/datapusher-classic.yml
@@ -10,8 +10,6 @@
     build_pkg_repo: "{{ datapusher_build_pkg_repo }}"
     build_pkg_requirements: "{{ datapusher_build_pkg_requirements }}"
     virtualenv: "{{ datapusher_virtual_env }}"
-  notify:
-    - restart apache2
 
 # TODO remove this code to resolve https://github.com/GSA/datagov-deploy/issues/1177
 - name: "Datapusher json content-type temp fix (content-type: application/json does not work now)"
@@ -38,5 +36,4 @@
     - etc/ckan/datapusher.wsgi
     - etc/ckan/datapusher_settings.py
     - etc/apache2/sites-enabled/datapusher.conf
-  notify:
-    - restart apache2
+  notify: restart apache2

--- a/ansible/roles/software/ckan/inventory/tasks/datapusher-classic.yml
+++ b/ansible/roles/software/ckan/inventory/tasks/datapusher-classic.yml
@@ -10,6 +10,8 @@
     build_pkg_repo: "{{ datapusher_build_pkg_repo }}"
     build_pkg_requirements: "{{ datapusher_build_pkg_requirements }}"
     virtualenv: "{{ datapusher_virtual_env }}"
+  notify:
+    - restart apache2
 
 # TODO remove this code to resolve https://github.com/GSA/datagov-deploy/issues/1177
 - name: "Datapusher json content-type temp fix (content-type: application/json does not work now)"

--- a/ansible/roles/software/ckan/inventory/tasks/datapusher-next.yml
+++ b/ansible/roles/software/ckan/inventory/tasks/datapusher-next.yml
@@ -26,8 +26,6 @@
     build_pkg_repo: "{{ datapusher_build_pkg_repo }}"
     build_pkg_requirements: "{{ datapusher_next_requirements }}"
     virtualenv: "{{ datapusher_virtual_env }}"
-  notify:
-    - restart apache2
 
 - name: install psycopg2
   pip:
@@ -47,5 +45,4 @@
     - etc/ckan/datapusher.wsgi
     - etc/ckan/datapusher_settings.py
     - etc/apache2/sites-enabled/datapusher.conf
-  notify:
-    - restart apache2
+  notify: restart apache2

--- a/ansible/roles/software/ckan/inventory/tasks/datapusher-next.yml
+++ b/ansible/roles/software/ckan/inventory/tasks/datapusher-next.yml
@@ -26,6 +26,8 @@
     build_pkg_repo: "{{ datapusher_build_pkg_repo }}"
     build_pkg_requirements: "{{ datapusher_next_requirements }}"
     virtualenv: "{{ datapusher_virtual_env }}"
+  notify:
+    - restart apache2
 
 - name: install psycopg2
   pip:

--- a/ansible/roles/software/ckan/inventory/tasks/main.yml
+++ b/ansible/roles/software/ckan/inventory/tasks/main.yml
@@ -8,6 +8,7 @@
       - xmlsec1
       - cron
       - supervisor
+  notify: restart supervisor
 
 - name: Assert newrelic_license_key is set
   assert:
@@ -113,7 +114,7 @@
   become: true
   when: inventory_next
   notify:
-    - restart supervisor
+    - reread supervisor
 
 - name: Configure inventory-classic server
   template:
@@ -124,7 +125,7 @@
     mode: 0640
   when: not inventory_next
   notify:
-    - restart supervisor
+    - reread supervisor
 
 - name: Configure inventory-next server
   template:
@@ -135,7 +136,7 @@
     mode: 0640
   when: inventory_next
   notify:
-    - restart supervisor
+    - reread supervisor
 
 - name: Copy CKAN server_start.sh
   copy:

--- a/ansible/roles/software/ckan/inventory/tasks/main.yml
+++ b/ansible/roles/software/ckan/inventory/tasks/main.yml
@@ -61,8 +61,7 @@
     virtualenv: '{{ project_source_new_code_path }}'
     virtualenv_python: "{{ inventory_python_home }}/bin/python"
     umask: "0022"
-  notify:
-    - restart ckan
+  notify: restart ckan
 
 - name: install repoze.who library for local login (if saml disabled)
   pip:
@@ -72,6 +71,7 @@
     state: present
   when:
     - not inventory_ckan_saml2_enabled
+  notify: restart ckan
 
 - name: create directories
   action: file path={{ item }} state=directory owner="www-data" group="www-data" mode=0755 recurse=yes

--- a/ansible/roles/software/ckan/inventory/tasks/main.yml
+++ b/ansible/roles/software/ckan/inventory/tasks/main.yml
@@ -113,7 +113,7 @@
   become: true
   when: inventory_next
   notify:
-    - reread supervisor
+    - reload supervisor
 
 - name: Configure inventory-classic server
   template:
@@ -124,7 +124,7 @@
     mode: 0640
   when: not inventory_next
   notify:
-    - reread supervisor
+    - reload supervisor
 
 - name: Configure inventory-next server
   template:
@@ -135,7 +135,7 @@
     mode: 0640
   when: inventory_next
   notify:
-    - reread supervisor
+    - reload supervisor
 
 - name: Copy CKAN server_start.sh
   copy:

--- a/ansible/roles/software/ckan/inventory/tasks/main.yml
+++ b/ansible/roles/software/ckan/inventory/tasks/main.yml
@@ -8,7 +8,6 @@
       - xmlsec1
       - cron
       - supervisor
-  notify: restart supervisor
 
 - name: Assert newrelic_license_key is set
   assert:

--- a/ansible/roles/software/ckan/inventory/tasks/main.yml
+++ b/ansible/roles/software/ckan/inventory/tasks/main.yml
@@ -54,8 +54,6 @@
     virtualenv: '{{ project_source_new_code_path }}'
     virtualenv_python: "{{ inventory_python_home }}/bin/python"
     umask: "0022"
-  notify:
-    - reload supervisor
 
 - name: install inventory app from requirements
   pip:
@@ -64,7 +62,7 @@
     virtualenv_python: "{{ inventory_python_home }}/bin/python"
     umask: "0022"
   notify:
-    - reload supervisor
+    - restart ckan
 
 - name: install repoze.who library for local login (if saml disabled)
   pip:
@@ -74,8 +72,6 @@
     state: present
   when:
     - not inventory_ckan_saml2_enabled
-  notify:
-    - reload supervisor
 
 - name: create directories
   action: file path={{ item }} state=directory owner="www-data" group="www-data" mode=0755 recurse=yes
@@ -87,7 +83,7 @@
   with_items:
     - etc/ckan/who.ini
   notify:
-    - reload supervisor
+    - restart ckan
 
 - name: Configure production.ini
   template: src={{ item }} dest=/{{ item }} owner=root group=www-data mode=0640
@@ -96,7 +92,7 @@
     - etc/apache2/sites-enabled/ckan.conf
   notify:
     - restart apache2
-    - reload supervisor
+    - restart ckan
 
 - name: Copy app .env
   template:
@@ -108,7 +104,7 @@
   become: true
   when: inventory_next
   notify:
-    - reload supervisor
+    - restart ckan
 
 - name: Remove old supervisor files
   file:
@@ -117,7 +113,7 @@
   become: true
   when: inventory_next
   notify:
-    - reload supervisor
+    - restart supervisor
 
 - name: Configure inventory-classic server
   template:
@@ -128,7 +124,7 @@
     mode: 0640
   when: not inventory_next
   notify:
-    - reload supervisor
+    - restart supervisor
 
 - name: Configure inventory-next server
   template:
@@ -139,7 +135,7 @@
     mode: 0640
   when: inventory_next
   notify:
-    - reload supervisor
+    - restart supervisor
 
 - name: Copy CKAN server_start.sh
   copy:
@@ -150,7 +146,7 @@
   become: true
   when: inventory_next
   notify:
-    - reload supervisor
+    - restart ckan
 
 - include_tasks: datapusher-next.yml
   tags:
@@ -178,7 +174,7 @@
     path: "{{ current_source_symlink }}"
     state: link
   notify:
-    - reload supervisor
+    - restart ckan
 
 - name: ensure supervisor is started and enabled
   service: name=supervisor state=started enabled=yes

--- a/ansible/roles/software/ckan/inventory/tasks/main.yml
+++ b/ansible/roles/software/ckan/inventory/tasks/main.yml
@@ -8,15 +8,11 @@
       - xmlsec1
       - cron
       - supervisor
-  notify: restart apache2
 
 - name: Assert newrelic_license_key is set
   assert:
     that: newrelic_license_key is defined
     fail_msg: newrelic_license_key is required but it is not set
-
-- name: ensure supervisor is started and enabled
-  service: name=supervisor state=started enabled=yes
 
 - name: Create log directory
   file: path={{ inventory_log_dir }} state=directory owner=root group=www-data mode=0750
@@ -58,7 +54,8 @@
     virtualenv: '{{ project_source_new_code_path }}'
     virtualenv_python: "{{ inventory_python_home }}/bin/python"
     umask: "0022"
-  notify: restart apache2
+  notify:
+    - reload supervisor
 
 - name: install inventory app from requirements
   pip:
@@ -66,7 +63,8 @@
     virtualenv: '{{ project_source_new_code_path }}'
     virtualenv_python: "{{ inventory_python_home }}/bin/python"
     umask: "0022"
-  notify: restart apache2
+  notify:
+    - reload supervisor
 
 - name: install repoze.who library for local login (if saml disabled)
   pip:
@@ -77,7 +75,6 @@
   when:
     - not inventory_ckan_saml2_enabled
   notify:
-    - restart apache2
     - reload supervisor
 
 - name: create directories
@@ -89,7 +86,8 @@
   action: copy src={{ item }} dest=/{{ item }} owner=root group=www-data mode=0640
   with_items:
     - etc/ckan/who.ini
-  notify: restart apache2
+  notify:
+    - reload supervisor
 
 - name: Configure production.ini
   template: src={{ item }} dest=/{{ item }} owner=root group=www-data mode=0640
@@ -98,6 +96,7 @@
     - etc/apache2/sites-enabled/ckan.conf
   notify:
     - restart apache2
+    - reload supervisor
 
 - name: Copy app .env
   template:
@@ -108,6 +107,8 @@
     group: root
   become: true
   when: inventory_next
+  notify:
+    - reload supervisor
 
 - name: Remove old supervisor files
   file:
@@ -115,6 +116,8 @@
     state: absent
   become: true
   when: inventory_next
+  notify:
+    - reload supervisor
 
 - name: Configure inventory-classic server
   template:
@@ -146,6 +149,8 @@
     remote_src: true
   become: true
   when: inventory_next
+  notify:
+    - reload supervisor
 
 - include_tasks: datapusher-next.yml
   tags:
@@ -172,12 +177,11 @@
     src: "{{ project_source_new_code_path }}"
     path: "{{ current_source_symlink }}"
     state: link
-  notify: restart apache2
+  notify:
+    - reload supervisor
 
-- name: point site_url in /etc/hosts to localhost
-  action: lineinfile dest=/etc/hosts line="127.0.0.1 {{ ckan_site_domain | regex_replace('https?\://','') }}" state=absent
-  tags:
-    - molecule-notest # Device or resource busy ranaming temp file
+- name: ensure supervisor is started and enabled
+  service: name=supervisor state=started enabled=yes
 
 - name: Ensure apache2 is started and enabled
   service: name=apache2 enabled={{ datagov_in_service | ternary('true', 'false') }} state={{ datagov_in_service | ternary('started', 'stopped') }}

--- a/ansible/roles/software/ckan/inventory/templates/etc/supervisor/conf.d/gunicorn-web-app-next.conf
+++ b/ansible/roles/software/ckan/inventory/templates/etc/supervisor/conf.d/gunicorn-web-app-next.conf
@@ -1,4 +1,4 @@
-[program:gunicorn-web-app]
+[program:ckan]
 command=/etc/ckan/server_start.sh -b localhost:5000 --proxy-allow-from="127.0.0.1"
 directory={{ project_source_new_code_path }}
 user=www-data

--- a/ansible/roles/software/ckan/inventory/templates/etc/supervisor/conf.d/gunicorn-web-app.conf
+++ b/ansible/roles/software/ckan/inventory/templates/etc/supervisor/conf.d/gunicorn-web-app.conf
@@ -1,4 +1,4 @@
-[program:gunicorn-web-app]
+[program:ckan]
 command={{ project_source_new_code_path }}/bin/gunicorn --worker-class gevent --paste /etc/ckan/production.ini -b localhost:5000 --proxy-allow-from="127.0.0.1"
 directory={{ project_source_new_code_path }}
 user=www-data


### PR DESCRIPTION
https://github.com/GSA/datagov-deploy/issues/2364

Now that we're using supervisor to run ckan (gunicorn), anything that effects
the ckan process should trigger a reload of the ckan process (supervisor).

Apache no longer cares about anything ckan, so it's pretty much a one-to-one
swap of the handlers.

For example, any change to production.ini, to the virtual environment, the
.env, supervisor configs, the ckan start script... apache doesn't care about
any of these, but supervisor does.

I also moved the supervisor service start to the end... no point instarting
supervisor until after the application code is installed (thinking about
first-time install).