### PR TITLE
[catalog] configurable ServerAlias

### DIFF
--- a/ansible/inventories/production/group_vars/all/vars.yml
+++ b/ansible/inventories/production/group_vars/all/vars.yml
@@ -1,5 +1,6 @@
 ---
 # catalog
+catalog_ckan_apache_server_name: "{{ catalog_host_public }}"
 catalog_ckan_app_version: master
 catalog_ckan_archiver_process_count: 3
 catalog_ckan_db_host: "{{ vault_catalog_ckan_db_host }}"

--- a/ansible/inventories/production/group_vars/catalog-admin/vars.yml
+++ b/ansible/inventories/production/group_vars/catalog-admin/vars.yml
@@ -1,2 +1,3 @@
 ---
+catalog_ckan_apache_server_name: "{{ catalog_host_admin }}"
 catalog_ckan_readwrite_configuration: readwrite

--- a/ansible/inventories/production/group_vars/catalog-next-web-admin/vars.yml
+++ b/ansible/inventories/production/group_vars/catalog-next-web-admin/vars.yml
@@ -1,5 +1,7 @@
 ---
 datagov_in_service: false  # TODO https://github.com/GSA/datagov-ckan-multi/issues/298 waiting on admin-catalog-next TLS certificate
+catalog_ckan_apache_server_alias:
+  - admin-catalog.data.gov
 catalog_ckan_apache_server_name: "{{ catalog_host_admin_next }}"
 catalog_ckan_readwrite_configuration: readwrite
 catalog_ckan_db_host: "{{ catalog_next_ckan_db_primary_host }}"

--- a/ansible/inventories/production/group_vars/catalog-next-web-admin/vars.yml
+++ b/ansible/inventories/production/group_vars/catalog-next-web-admin/vars.yml
@@ -1,5 +1,6 @@
 ---
 datagov_in_service: false  # TODO https://github.com/GSA/datagov-ckan-multi/issues/298 waiting on admin-catalog-next TLS certificate
+catalog_ckan_apache_server_name: "{{ catalog_host_admin_next }}"
 catalog_ckan_readwrite_configuration: readwrite
 catalog_ckan_db_host: "{{ catalog_next_ckan_db_primary_host }}"
 catalog_ckan_solr_host: "{{ catalog_next_ckan_solr_primary_host }}"

--- a/ansible/inventories/production/group_vars/catalog-next/vars.yml
+++ b/ansible/inventories/production/group_vars/catalog-next/vars.yml
@@ -2,6 +2,8 @@
 app_repo: https://github.com/GSA/catalog.data.gov
 catalog_ckan_app_version: master
 
+catalog_ckan_apache_server_alias:
+  - catalog.data.gov
 catalog_ckan_apache_server_name: "{{ catalog_host_public_next }}"
 catalog_ckan_db_host: "{{ catalog_next_ckan_db_replica_a_host }}"
 catalog_ckan_db_name: "{{ catalog_next_ckan_db_name }}"

--- a/ansible/inventories/production/group_vars/catalog-next/vars.yml
+++ b/ansible/inventories/production/group_vars/catalog-next/vars.yml
@@ -2,6 +2,7 @@
 app_repo: https://github.com/GSA/catalog.data.gov
 catalog_ckan_app_version: master
 
+catalog_ckan_apache_server_name: "{{ catalog_host_public_next }}"
 catalog_ckan_db_host: "{{ catalog_next_ckan_db_replica_a_host }}"
 catalog_ckan_db_name: "{{ catalog_next_ckan_db_name }}"
 catalog_ckan_db_pass: "{{ catalog_next_ckan_db_pass }}"

--- a/ansible/inventories/sandbox/group_vars/catalog-next/vars.yml
+++ b/ansible/inventories/sandbox/group_vars/catalog-next/vars.yml
@@ -2,6 +2,9 @@
 catalog_ckan_service_url: https://{{ catalog_host_public_next }}
 ckan_site_domain: https://{{ catalog_host_public_next }}
 
+catalog_ckan_apache_server_name: "{{ catalog_host_public_next }}"
+catalog_ckan_apache_server_alias:
+  - d1xr5ix4dos50f.cloudfront.net
 catalog_ckan_db_host: "{{ catalog_next_postgresql_login_host }}"
 catalog_ckan_db_name: "{{ catalog_next_ckan_db_name }}"
 catalog_ckan_db_pass: "{{ catalog_next_postgresql_login_password }}"

--- a/ansible/inventories/sandbox/group_vars/catalog-web/vars.yml
+++ b/ansible/inventories/sandbox/group_vars/catalog-web/vars.yml
@@ -20,6 +20,9 @@ ckan_instance_uuid: "{{ catalog_ckan_instance_uuid }}"
 # token_dat for Google Analytics
 token_dat: "{{ catalog_ckan_token_dat }}"
 
+catalog_ckan_apache_server_name: "{{ catalog_host_public }}"
+catalog_ckan_apache_server_alias:
+  - d1xr5ix4dos50f.cloudfront.net
 catalog_ckan_instance_secret: "{{ vault_catalog_ckan_instance_secret }}"
 catalog_ckan_instance_uuid: "{{ vault_catalog_ckan_instance_uuid }}"
 catalog_ckan_token_dat: "{{ vault_catalog_ckan_token_dat }}"

--- a/ansible/inventories/staging/group_vars/all/vars.yml
+++ b/ansible/inventories/staging/group_vars/all/vars.yml
@@ -1,5 +1,6 @@
 ---
 # catalog
+catalog_ckan_apache_server_name: "{{ catalog_host_public }}"
 catalog_ckan_app_version: master
 catalog_ckan_archiver_process_count: 3
 # read-only database variables

--- a/ansible/inventories/staging/group_vars/catalog-admin/vars.yml
+++ b/ansible/inventories/staging/group_vars/catalog-admin/vars.yml
@@ -1,2 +1,3 @@
 ---
+catalog_ckan_apache_server_name: "{{ catalog_host_admin }}"
 catalog_ckan_readwrite_configuration: readwrite

--- a/ansible/inventories/staging/group_vars/catalog-next-web-admin/vars.yml
+++ b/ansible/inventories/staging/group_vars/catalog-next-web-admin/vars.yml
@@ -1,4 +1,5 @@
 ---
+catalog_ckan_apache_server_name: "{{ catalog_host_admin_next }}"
 catalog_ckan_readwrite_configuration: readwrite
 catalog_ckan_db_host: "{{ catalog_next_ckan_db_primary_host }}"
 catalog_ckan_solr_host: "{{ catalog_next_ckan_solr_primary_host }}"

--- a/ansible/inventories/staging/group_vars/catalog-next/vars.yml
+++ b/ansible/inventories/staging/group_vars/catalog-next/vars.yml
@@ -2,6 +2,7 @@
 app_repo: https://github.com/GSA/catalog.data.gov
 catalog_ckan_app_version: master
 
+catalog_ckan_apache_server_name: "{{ catalog_host_public_next }}"
 catalog_ckan_db_host: "{{ catalog_next_ckan_db_replica_host }}"
 catalog_ckan_db_name: "{{ catalog_next_ckan_db_name }}"
 catalog_ckan_db_pass: "{{ catalog_next_ckan_db_pass }}"

--- a/ansible/roles/software/ckan/catalog/ckan-app/defaults/main.yml
+++ b/ansible/roles/software/ckan/catalog/ckan-app/defaults/main.yml
@@ -3,6 +3,8 @@ datagov_team_email: team@example.com
 
 catalog_app_type: web  # either web or worker
 catalog_ckan_access_log: "{{ catalog_log_dir }}/ckan.access.log"
+catalog_ckan_apache_server_alias: []
+catalog_ckan_apache_server_name: ckan
 catalog_ckan_readwrite_configuration: default  # One of [default, readwrite, readonly]
 catalog_ckan_app_version: master
 catalog_ckan_error_log: "{{ catalog_log_dir }}/ckan.error.log"

--- a/ansible/roles/software/ckan/catalog/ckan-app/molecule/catalog-next/tests/test_default.py
+++ b/ansible/roles/software/ckan/catalog/ckan-app/molecule/catalog-next/tests/test_default.py
@@ -109,7 +109,3 @@ def test_apache_site(host):
     assert f.group == 'www-data'
     assert f.mode == 0o644
     assert f.contains('ErrorLog /var/log/ckan/ckan.error.log')
-
-    # catalog domain ServerName, catalog-next in ServerAlias
-    assert f.contains('ServerName %s' % catalog_host_public)
-    assert f.contains('ServerAlias %s' % catalog_host_public_next)

--- a/ansible/roles/software/ckan/catalog/ckan-app/molecule/default/playbook.yml
+++ b/ansible/roles/software/ckan/catalog/ckan-app/molecule/default/playbook.yml
@@ -3,4 +3,8 @@
   hosts: all
   roles:
     - role: ckan-app
+      catalog_ckan_apache_server_name: ckan
+      catalog_ckan_apache_server_alias:
+        - red
+        - blue
       catalog_ckan_email_from: no-reply@data.gov

--- a/ansible/roles/software/ckan/catalog/ckan-app/molecule/default/tests/test_default.py
+++ b/ansible/roles/software/ckan/catalog/ckan-app/molecule/default/tests/test_default.py
@@ -107,6 +107,15 @@ def test_apache_site(host):
     assert f.mode == 0o644
     assert f.contains('ErrorLog /var/log/ckan/ckan.error.log')
 
+    assert f.contains('ServerName ckan'), \
+        'ServerName should be catalog_ckan_apache_server_name'
+    assert f.contains('ServerAlias red blue'), \
+        'ServerAlias should include catalog_ckan_apache_server_alias'
+    assert f.contains('ServerAlias .* localhost'), \
+        'ServerAlias should include localhost'
+    assert f.contains('ServerAlias .* ckan-catalog-app-'), \
+        'ServerAlias should include hostname/FQDN'
+
     # In default configuration, there should be no redirects between readwrite
     # and readonly instances.
     assert not f.contains('RewriteRule.*/user/login'), \

--- a/ansible/roles/software/ckan/catalog/ckan-app/molecule/readwrite/tests/test_default.py
+++ b/ansible/roles/software/ckan/catalog/ckan-app/molecule/readwrite/tests/test_default.py
@@ -113,8 +113,6 @@ def test_apache_site(host):
     # In readwrite configuration, ServerName is admin site, not
     # public site.
     assert f.contains('Redirect 404 /')
-    assert f.contains('ServerName %s' % catalog_host_admin)
-    assert not f.contains('ServerName %s' % catalog_host_public)
 
     # In readwrite configuration, redirect unauthenticated requests to the
     # readonly url.

--- a/ansible/roles/software/ckan/catalog/ckan-app/templates/etc_apache2_sites-enabled_ckan.conf.j2
+++ b/ansible/roles/software/ckan/catalog/ckan-app/templates/etc_apache2_sites-enabled_ckan.conf.j2
@@ -12,19 +12,8 @@ SSLEngine on
 </VirtualHost>
 
 <VirtualHost 0.0.0.0:80>
-{% if catalog_ckan_readwrite_configuration == 'readwrite' %}
-    ServerName {{ catalog_host_admin }}
-  {% if ckan_catalog_next == true %}
-    ServerAlias {{ catalog_host_admin_next }}
-  {% endif %}
-{% else %}
-    ServerName {{ catalog_host_public }}
-  {% if ckan_catalog_next == true %}
-    ServerAlias {{ catalog_host_public_next }}
-  {% endif %}
-{% endif %}
-    ServerAlias localhost {{ ansible_default_ipv4.address | default('') }}
-    ServerAlias {{ ansible_fqdn }}
+    ServerName {{ catalog_ckan_apache_server_name }}
+    ServerAlias {{ catalog_ckan_apache_server_alias | join(' ') }} {{ ansible_fqdn }} localhost {{ ansible_default_ipv4.address | default('') }}
 
     # CSW endpoints provided by pycsw
     # based on request URI


### PR DESCRIPTION
https://github.com/GSA/datagov-ckan-multi/issues/401

Support configurable ServerAlias to allow Launch Plan testing for catalog-next.
Here we add d1xr5ix4dos50f.cloudfront.net in sandbox to represent
catalog.data.gov in our testing.

This also adds catalog.data.gov to catalog-next in order for the production
transition.