### PR TITLE
Re-enable CSW app in sandbox

### DIFF
--- a/ansible/inventories/sandbox/hosts
+++ b/ansible/inventories/sandbox/hosts
@@ -42,8 +42,11 @@ inventory-web1tf.internal.sandbox.datagov.us
 [jenkins]
 jenkins1tf.internal.sandbox.datagov.us
 
-[pycsw-web]
-[pycsw-worker]
+[pycsw-web:children]
+catalog-next-web
+
+[pycsw-worker:children]
+catalog-next-worker
 
 [wordpress-web]
 wordpress-web1tf.internal.sandbox.datagov.us

--- a/ansible/pycsw.yml
+++ b/ansible/pycsw.yml
@@ -22,7 +22,7 @@
 
     - name: assert csw-collection is up
       uri:
-        url: {{ catalog_url_public }}/csw?service=CSW&version=2.0.2&request=GetCapabilities
+        url: "{{ catalog_url_public }}/csw?service=CSW&version=2.0.2&request=GetCapabilities"
         follow_redirects: none
         status_code: 200
         return_content: true
@@ -45,7 +45,7 @@
 
     - name: assert csw-all is up
       uri:
-        url: {{ catalog_url_public }}/csw-all?service=CSW&version=2.0.2&request=GetCapabilities
+        url: "{{ catalog_url_public }}/csw-all?service=CSW&version=2.0.2&request=GetCapabilities"
         follow_redirects: none
         status_code: 200
         return_content: true

--- a/ansible/pycsw.yml
+++ b/ansible/pycsw.yml
@@ -22,7 +22,7 @@
 
     - name: assert csw-collection is up
       uri:
-        url: http://{{ ansible_fqdn }}/csw?service=CSW&version=2.0.2&request=GetCapabilities
+        url: {{ catalog_url_public }}/csw?service=CSW&version=2.0.2&request=GetCapabilities
         follow_redirects: none
         status_code: 200
         return_content: true
@@ -45,7 +45,7 @@
 
     - name: assert csw-all is up
       uri:
-        url: http://{{ ansible_fqdn }}/csw-all?service=CSW&version=2.0.2&request=GetCapabilities
+        url: {{ catalog_url_public }}/csw-all?service=CSW&version=2.0.2&request=GetCapabilities
         follow_redirects: none
         status_code: 200
         return_content: true


### PR DESCRIPTION
Related to [Multi#306](https://github.com/GSA/datagov-ckan-multi/issues/306)

We had an [error to deploy CSW app](https://ci.sandbox.datagov.us/blue/organizations/jenkins/deploy-ci-platform/detail/deploy-ci-platform/285/pipeline/) for the sandbox
[This commit](https://github.com/GSA/datagov-deploy/commit/32b8997ff95c2f6f71f9a3dc8a328e00a697f9d1) disables CSW after the fail
The error is a **404** for this URL: http://catalog-next-web1tf.internal.sandbox.datagov.us/csw?service=CSW&version=2.0.2&request=GetCapabilities
Note the **"catalog-next-web1tf.internal.sandbox.datagov.us"** instead the real public URL **"catalog-next.sandbox.datagov.us"**
I created this PR to try to fix this and try again

This PR enables the CSW application for the sandbox environment and change the test URL to fit the real public host URL