### PR TITLE
[pycsw] fixes for pycsw on trusty

### DIFF
--- a/ansible/group_vars/all/vars.yml
+++ b/ansible/group_vars/all/vars.yml
@@ -180,6 +180,11 @@ postfix_inet_interfaces: loopback-only  # only listen on loopback interfaces, we
 postfix_smtpd_tls_key_file: "{{ default_tls_host_key_filepath }}"
 postfix_smtpd_tls_cert_file: "{{ default_tls_host_certificate_filepath }}"
 
+
+# pyenv
+pyenv_update_git_install: true
+
+
 # solr
 solr_home: /data/solr5
 solr_version: 5.5.5

--- a/ansible/inventories/production/group_vars/v1/vars.yml
+++ b/ansible/inventories/production/group_vars/v1/vars.yml
@@ -1,3 +1,6 @@
 ---
 # common
 common_ubuntu_advantage_enabled: true
+
+# pycsw
+pycsw_python_version: 3.6.12  # 3.6.x is the latest python3 that will build with our version of openssl

--- a/ansible/inventories/sandbox/group_vars/catalog-next-worker/vars.yml
+++ b/ansible/inventories/sandbox/group_vars/catalog-next-worker/vars.yml
@@ -2,6 +2,3 @@
 catalog_app_type: worker
 catalog_enable_clean_harvest_logs: true
 catalog_pycsw_cron_enable: false
-
-pycsw_base_url: https://catalog-next.sandbox.datagov.us
-pycsw_ckan_url: https://catalog-next.sandbox.datagov.us

--- a/ansible/inventories/sandbox/group_vars/catalog-next/vars.yml
+++ b/ansible/inventories/sandbox/group_vars/catalog-next/vars.yml
@@ -16,6 +16,3 @@ catalog_ckan_redis_host: "{{ catalog_next_ckan_redis_host }}"
 catalog_ckan_redis_password: "{{ catalog_next_ckan_redis_password }}"
 
 catalog_ckan_plugins_default: "{{ catalog_next_ckan_plugins_default }}"
-
-pycsw_base_url: https://catalog-next.sandbox.datagov.us
-pycsw_ckan_url: https://catalog-next.sandbox.datagov.us

--- a/ansible/inventories/sandbox/group_vars/pycsw-web-v2/vars.yml
+++ b/ansible/inventories/sandbox/group_vars/pycsw-web-v2/vars.yml
@@ -1,0 +1,5 @@
+---
+# For testing pycsw loading from catalog-next in sandbox. We have no intention
+# of making this change in staging/production.
+pycsw_base_url: https://catalog-next.sandbox.datagov.us
+pycsw_ckan_url: https://catalog-next.sandbox.datagov.us

--- a/ansible/inventories/sandbox/group_vars/pycsw-worker-v2/vars.yml
+++ b/ansible/inventories/sandbox/group_vars/pycsw-worker-v2/vars.yml
@@ -1,0 +1,5 @@
+---
+# For testing pycsw loading from catalog-next in sandbox. We have no intention
+# of making this change in staging/production.
+pycsw_base_url: https://catalog-next.sandbox.datagov.us
+pycsw_ckan_url: https://catalog-next.sandbox.datagov.us

--- a/ansible/inventories/sandbox/group_vars/pycsw/vars.yml
+++ b/ansible/inventories/sandbox/group_vars/pycsw/vars.yml
@@ -1,0 +1,2 @@
+---
+pycsw_python_version: 3.8.6

--- a/ansible/inventories/sandbox/group_vars/v1/vars.yml
+++ b/ansible/inventories/sandbox/group_vars/v1/vars.yml
@@ -1,0 +1,2 @@
+---
+pycsw_python_version: 3.6.12  # 3.6.x is the latest python3 that will build with our version of openssl

--- a/ansible/inventories/sandbox/hosts
+++ b/ansible/inventories/sandbox/hosts
@@ -42,6 +42,10 @@ inventory-web1tf.internal.sandbox.datagov.us
 [jenkins]
 jenkins1tf.internal.sandbox.datagov.us
 
+[pycsw:children]
+pycsw-web
+pycsw-worker
+
 [pycsw-web-v1]
 catalog-web1tf.internal.sandbox.datagov.us
 

--- a/ansible/inventories/sandbox/hosts
+++ b/ansible/inventories/sandbox/hosts
@@ -42,11 +42,25 @@ inventory-web1tf.internal.sandbox.datagov.us
 [jenkins]
 jenkins1tf.internal.sandbox.datagov.us
 
+[pycsw-web-v1]
+catalog-web1tf.internal.sandbox.datagov.us
+
+[pycsw-worker-v1]
+catalog-harvester1tf.internal.sandbox.datagov.us
+
+[pycsw-web-v2]
+catalog-next-web1tf.internal.sandbox.datagov.us
+
+[pycsw-worker-v2]
+catalog-harvester-next1tf.internal.sandbox.datagov.us
+
 [pycsw-web:children]
-catalog-next-web
+pycsw-web-v1
+pycsw-web-v2
 
 [pycsw-worker:children]
-catalog-next-worker
+pycsw-worker-v1
+pycsw-worker-v2
 
 [wordpress-web]
 wordpress-web1tf.internal.sandbox.datagov.us
@@ -55,6 +69,8 @@ wordpress-web1tf.internal.sandbox.datagov.us
 catalog-harvester
 catalog-web
 inventory-web
+pycsw-web-v1
+pycsw-worker-v1
 
 [v2:children]
 catalog-fgdc2iso
@@ -63,7 +79,7 @@ inventory-next
 dashboard-web
 jenkins
 jumpbox
-pycsw-web
-pycsw-worker
+pycsw-web-v2
+pycsw-worker-v2
 solr
 wordpress-web

--- a/ansible/inventories/staging/group_vars/v1/vars.yml
+++ b/ansible/inventories/staging/group_vars/v1/vars.yml
@@ -1,3 +1,6 @@
 ---
 # common
 common_ubuntu_advantage_enabled: true
+
+# pycsw
+pycsw_python_version: 3.6.12  # 3.6.x is the latest python3 that will build with our version of openssl


### PR DESCRIPTION
We accidently removed pycsw trusty hosts from sandbox. I ran into an error on staging when deploying a recent pycsw. This PR adds the trusty hosts back and updates python to version 3 to match what is in pycsw today.