### PR TITLE
[hotfix][pycsw] pin to python2 version

### DIFF
--- a/ansible/inventories/production/group_vars/all/vars.yml
+++ b/ansible/inventories/production/group_vars/all/vars.yml
@@ -164,7 +164,8 @@ inventory_ckan_solr_port: "8983"
 newrelic_license_key: "{{ vault_newrelic_license_key }}"
 
 
-pycsw_app_version: datagov/v2.4.x
+#pycsw_app_version: datagov/v2.4.x
+pycsw_app_version: a0120f921f3f787a40f1f9af3fd80d05963b974c   # TODO remove me before next release https://github.com/GSA/datagov-deploy/pull/2385
 pycsw_base_url: https://catalog.data.gov
 pycsw_ckan_url: https://catalog.data.gov
 pycsw_db_host: "{{ catalog_pycsw_db_host }}"

--- a/ansible/inventories/staging/group_vars/all/vars.yml
+++ b/ansible/inventories/staging/group_vars/all/vars.yml
@@ -179,8 +179,10 @@ inventory_next_datapusher_db_name: "{{ vault_inventory_next_datapusher_db_name }
 newrelic_license_key: "{{ vault_newrelic_license_key }}"
 
 
+# pycsw
 pycsw_app_environment: staging
-pycsw_app_version: datagov/v2.4.x
+#pycsw_app_version: datagov/v2.4.x
+pycsw_app_version: a0120f921f3f787a40f1f9af3fd80d05963b974c   # TODO remove me before next release https://github.com/GSA/datagov-deploy/pull/2385
 pycsw_base_url: https://catalog-datagov.dev-ocsit.bsp.gsa.gov
 pycsw_ckan_url: https://catalog-datagov.dev-ocsit.bsp.gsa.gov
 pycsw_db_host: "{{ catalog_pycsw_db_host }}"


### PR DESCRIPTION
Pycsw dependencies were recently bumped to python3. Pin to a python2 version
and we'll update pycsw to python3 in the next release.