### PR TITLE
[pycsw] setup pycsw routes correctly

### DIFF
--- a/ansible/inventories/sandbox/group_vars/pycsw-web-v2/vars.yml
+++ b/ansible/inventories/sandbox/group_vars/pycsw-web-v2/vars.yml
@@ -3,3 +3,8 @@
 # of making this change in staging/production.
 pycsw_base_url: https://catalog-next.sandbox.datagov.us
 pycsw_ckan_url: https://catalog-next.sandbox.datagov.us
+
+pycsw_db_host: "{{ catalog_next_postgresql_login_host }}"
+pycsw_db_name: pycsw
+pycsw_db_password: "{{ catalog_next_postgresql_login_password }}"
+pycsw_db_user: "{{ catalog_next_postgresql_login_user }}"

--- a/ansible/inventories/sandbox/group_vars/pycsw-worker-v2/vars.yml
+++ b/ansible/inventories/sandbox/group_vars/pycsw-worker-v2/vars.yml
@@ -3,3 +3,8 @@
 # of making this change in staging/production.
 pycsw_base_url: https://catalog-next.sandbox.datagov.us
 pycsw_ckan_url: https://catalog-next.sandbox.datagov.us
+
+pycsw_db_host: "{{ catalog_next_postgresql_login_host }}"
+pycsw_db_name: pycsw
+pycsw_db_password: "{{ catalog_next_postgresql_login_password }}"
+pycsw_db_user: "{{ catalog_next_postgresql_login_user }}"

--- a/ansible/roles/software/ckan/catalog/ckan-app/templates/etc_apache2_sites-enabled_ckan.conf.j2
+++ b/ansible/roles/software/ckan/catalog/ckan-app/templates/etc_apache2_sites-enabled_ckan.conf.j2
@@ -12,11 +12,14 @@ SSLEngine on
 </VirtualHost>
 
 <VirtualHost 0.0.0.0:80>
-    ServerName {{ catalog_ckan_apache_server_name }}
-    ServerAlias {{ catalog_ckan_apache_server_alias | join(' ') }} {{ ansible_fqdn }} localhost {{ ansible_default_ipv4.address | default('') }}
+  ServerName {{ catalog_ckan_apache_server_name }}
+  ServerAlias {{ catalog_ckan_apache_server_alias | join(' ') }} {{ ansible_fqdn }} localhost {{ ansible_default_ipv4.address | default('') }}
 
-    # CSW endpoints provided by pycsw
-    # based on request URI
+  # CSW endpoints provided by pycsw
+  # full CSW, all metadata
+  ProxyPass /csw-all http://localhost:8001
+  # default CSW, collection level metadata
+  ProxyPass /csw http://localhost:8000
 
   {% if ckan_uses_gunicorn %}
     # gunicorn configuration
@@ -25,12 +28,6 @@ SSLEngine on
     ProxyPreserveHost On
     RequestHeader set X-Forwarded-Proto https
   {% else %}
-    # full CSW, all metadata
-    ProxyPass /csw-all http://localhost:8001
-
-    # default CSW, collection level metadata
-    ProxyPass /csw http://localhost:8000
-
     WSGIScriptAlias / /etc/ckan/apache.wsgi
 
     # Pass authorization info on (needed for rest api).


### PR DESCRIPTION
Pycsw routes should not depend on ckan. Pycsw is always using gunicorn.