### PR TITLE
Promote pycsw and fgdc2iso to top level playbook

### DIFF
--- a/ansible/catalog.yml
+++ b/ansible/catalog.yml
@@ -10,7 +10,3 @@
 - import_playbook: fgdc2iso.yml
   tags:
     - fgdc2iso
-
-- import_playbook: pycsw.yml
-  tags:
-    - pycsw

--- a/ansible/catalog.yml
+++ b/ansible/catalog.yml
@@ -6,7 +6,3 @@
 - import_playbook: catalog-worker.yml
   tags:
     - worker
-
-- import_playbook: fgdc2iso.yml
-  tags:
-    - fgdc2iso

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -33,6 +33,9 @@
 - import_playbook: inventory.yml
   tags:
     - inventory
+- import_playbook: pycsw.yml
+  tags:
+    - pycsw
 
 # Validation and cleanup
 #########################

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -11,6 +11,9 @@
 - import_playbook: jumpbox.yml
   tags:
     - jumpbox
+- import_playbook: fgdc2iso.yml
+  tags:
+    - fgdc2iso
 - import_playbook: solr.yml
   tags:
     - solr


### PR DESCRIPTION
Mostly to speed up running the catalog playbook, but also to emphasize that these are independent apps/services from catalog and should be though of as such.

I'm 95% sure this is safe. I know pycsw still has a hidden dependency on the apache configuration which is in the ckan-app role.