### PR TITLE
[jumpbox] add localhost to jumpbox_ips

### DIFF
--- a/ansible/group_vars/all/vars.yml
+++ b/ansible/group_vars/all/vars.yml
@@ -129,8 +129,11 @@ inventory_ckan_plugins_default:
   - text_view
   - usmetadata
 
+
 # Limit SSH Access
-jumpbox_ips: ["10.0.0.0/8"]
+jumpbox_ips:
+  - "10.0.0.0/8"
+  - "127.0.0.1"
 
 
 # newrelic monitoring


### PR DESCRIPTION
This allows non-ubuntu users to ssh into the jumpbox as the ubuntu user from the
jumpbox. If you run a playbook as a non-ubuntu user, the playbook would fail on
the jumpbox with SSH access denied error. Allowing localhost resolves this.