### PR TITLE
Revert "[pycsw] pin to python2 version"

### DIFF
--- a/ansible/inventories/production/group_vars/all/vars.yml
+++ b/ansible/inventories/production/group_vars/all/vars.yml
@@ -165,8 +165,7 @@ inventory_ckan_solr_port: "8983"
 newrelic_license_key: "{{ vault_newrelic_license_key }}"
 
 
-#pycsw_app_version: datagov/v2.4.x
-pycsw_app_version: a0120f921f3f787a40f1f9af3fd80d05963b974c   # TODO remove me before next release https://github.com/GSA/datagov-deploy/pull/2385
+pycsw_app_version: datagov/v2.4.x
 pycsw_base_url: https://catalog.data.gov
 pycsw_ckan_url: https://catalog.data.gov
 pycsw_db_host: "{{ catalog_pycsw_db_host }}"

--- a/ansible/inventories/staging/group_vars/all/vars.yml
+++ b/ansible/inventories/staging/group_vars/all/vars.yml
@@ -180,10 +180,8 @@ inventory_next_datapusher_db_name: "{{ vault_inventory_next_datapusher_db_name }
 newrelic_license_key: "{{ vault_newrelic_license_key }}"
 
 
-# pycsw
 pycsw_app_environment: staging
-#pycsw_app_version: datagov/v2.4.x
-pycsw_app_version: a0120f921f3f787a40f1f9af3fd80d05963b974c   # TODO remove me before next release https://github.com/GSA/datagov-deploy/pull/2385
+pycsw_app_version: datagov/v2.4.x
 pycsw_base_url: https://catalog-datagov.dev-ocsit.bsp.gsa.gov
 pycsw_ckan_url: https://catalog-datagov.dev-ocsit.bsp.gsa.gov
 pycsw_db_host: "{{ catalog_pycsw_db_host }}"


### PR DESCRIPTION
Use the latest (defaults to datagov/v2.4.x branch) pycsw from our fork now that
python3 support is in place.

This reverts commit 43c3044435ddad990872a690e6bf655d86421a69.