### PR TITLE
Update tracking information

### DIFF
--- a/ansible/roles/software/ckan/catalog/ckan-app/templates/catalog-next/etc_ckan_production.ini.j2
+++ b/ansible/roles/software/ckan/catalog/ckan-app/templates/catalog-next/etc_ckan_production.ini.j2
@@ -190,7 +190,7 @@ ckan.hide_activity_from_users = %(ckan.site_id)s
 #smtp.password = your_password
 smtp.mail_from = {{ catalog_ckan_email_from }}
 
-ckan.tracking_enabled = False
+ckan.tracking_enabled = True
 set debug = False
 
 ## Harvest settings


### PR DESCRIPTION
Related to [DataGovCatalog#10](https://github.com/GSA/ckanext-datagovcatalog/issues/10)

This PR:
 - Enable tracking information for catalog-next