### PR TITLE
Redirect / to /dataset

### DIFF
--- a/ansible/roles/software/ckan/catalog/ckan-app/templates/etc_apache2_sites-enabled_ckan.conf.j2
+++ b/ansible/roles/software/ckan/catalog/ckan-app/templates/etc_apache2_sites-enabled_ckan.conf.j2
@@ -62,6 +62,9 @@ SSLEngine on
     # Header set Content-Security-Policy "default-src 'self'"
 
     RewriteEngine On
+    RewriteCond %{HTTP_REFERER} !{{saml2_idp_entry}} [NC]
+    RewriteRule ^/$ /dataset [R]
+
 {% if catalog_ckan_readwrite_configuration == 'readwrite' %}
     {# Allow login, redirect any unauthed requests to the readonly site #}
     RewriteCond %{REQUEST_URI}     !^/api/action/status_show


### PR DESCRIPTION
Related to #2083 

This PR adds a redirection from `/` to `/dataset`

## Notes

The catalog-next in the sandbox already include the expected redirection

<pre>
$ curl -v catalog-next.sandbox.datagov.us > /dev/null

> GET / HTTP/1.1
> Host: catalog-next.sandbox.datagov.us
> User-Agent: curl/7.68.0
> Accept: */*
<b>< HTTP/1.1 302 Found</b>

< Date: Mon, 09 Nov 2020 10:51:48 GMT
< Content-Type: text/plain; charset=utf8
< Transfer-Encoding: chunked
< Connection: keep-alive
< Server: gunicorn/19.10.0
<b>< Location: https://catalog-next.sandbox.datagov.us/dataset</b>
< X-Frame-Options: SAMEORIGIN
< X-XSS-Protection: 1; mode=block
< X-Content-Type-Options: nosniff
< Access-Control-Allow-Origin: *
< Access-Control-Allow-Methods: POST, PUT, GET, DELETE, OPTIONS
< Access-Control-Allow-Headers: X-CKAN-API-KEY, Authorization, Content-Type
< Referrer-Policy: origin
</pre>

I'm not able to found where this behaviour is defined but it seems to work in the sandbox

New production is not ready

<pre>
curl -v -L catalog-next.data.gov > /dev/null
> GET / HTTP/1.1
> Host: catalog-next.data.gov
> User-Agent: curl/7.68.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
<b>< HTTP/1.1 302 Found : Moved Temporarily</b>
<b>< Location: https://catalog-next.data.gov/</b>
< Connection: close
< Cache-Control: no-cache
< Pragma: no-cache
 ... 
*  SSL certificate verify ok.
> GET / HTTP/1.1
> Host: catalog-next.data.gov
> User-Agent: curl/7.68.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
<b>< HTTP/1.1 302 Found</b>
< Date: Tue, 10 Nov 2020 15:07:24 GMT
< Server: gunicorn/19.10.0
< Content-Type: text/plain; charset=utf8
<b>< Location: https://catalog-next.data.gov/dataset</b>
</pre>