### PR TITLE
Add credentials to next environments

### DIFF
--- a/ansible/roles/software/ckan/catalog/ckan-app/templates/catalog-next/etc_ckan_production.ini.j2
+++ b/ansible/roles/software/ckan/catalog/ckan-app/templates/catalog-next/etc_ckan_production.ini.j2
@@ -240,6 +240,11 @@ ckanext.geodatagov.metrics_csv.aws_storage_path = gsa/catalog-next/metrics/
 ckanext.geodatagov.s3sitemap.aws_storage_path = gsa/catalog-next/sitemap/
 ckanext.geodatagov.jsonlexport.aws_storage_path = gsa/catalog-next/jsonl/
 
+ckanext.geodatagov.aws_use_ami_role = true
+ckanext.geodatagov.aws_bucket_name = {{ catalog_bucket_name }}
+ckanext.geodatagov.aws_access_key_id = _placeholder
+ckanext.geodatagov.aws_secret_access_key = _placeholder
+
 # DataGovTheme settings
 
 ckanext.datagovtheme.use.archiver=false


### PR DESCRIPTION
Related to [Multi#480](https://github.com/GSA/datagov-ckan-multi/issues/480)

This PR adds AWS S3 credentials to catalog-next