### PR TITLE
Redirect "/" and "" to "/dataset"

### DIFF
--- a/ansible/roles/software/ckan/catalog/ckan-app/templates/etc_apache2_sites-enabled_ckan.conf.j2
+++ b/ansible/roles/software/ckan/catalog/ckan-app/templates/etc_apache2_sites-enabled_ckan.conf.j2
@@ -63,7 +63,7 @@ SSLEngine on
 
     RewriteEngine On
     RewriteCond %{HTTP_REFERER} !{{saml2_idp_entry}} [NC]
-    RewriteRule ^/$ /dataset [R]
+    RewriteRule ^(\/?)$ /dataset [R]
 
 {% if catalog_ckan_readwrite_configuration == 'readwrite' %}
     {# Allow login, redirect any unauthed requests to the readonly site #}


### PR DESCRIPTION
Related to #2083 

This PR redirect `"/"` and `""` to `"/dataset"`

The [previous PR](https://github.com/GSA/datagov-deploy/pull/2407) worked but just for the `"/"` URL. This PR improve this behaviour.