### PR TITLE
Remove host_vars for catalog-next-web

### DIFF
--- a/ansible/inventories/production/host_vars/catalogbweb1p.prod-ocsit.bsp.gsa.gov/vars.yml
+++ b/ansible/inventories/production/host_vars/catalogbweb1p.prod-ocsit.bsp.gsa.gov/vars.yml
@@ -1,2 +1,0 @@
----
-catalog_ckan_solr_host: datagov-solr2p-v2.prod-ocsit.bsp.gsa.gov

--- a/ansible/inventories/production/host_vars/catalogbweb2p.prod-ocsit.bsp.gsa.gov/vars.yml
+++ b/ansible/inventories/production/host_vars/catalogbweb2p.prod-ocsit.bsp.gsa.gov/vars.yml
@@ -1,2 +1,0 @@
----
-catalog_ckan_solr_host: datagov-solr2p-v2.prod-ocsit.bsp.gsa.gov

--- a/ansible/inventories/production/host_vars/catalogweb1p.prod-ocsit.bsp.gsa.gov/vars.yml
+++ b/ansible/inventories/production/host_vars/catalogweb1p.prod-ocsit.bsp.gsa.gov/vars.yml
@@ -1,2 +1,0 @@
----
-catalog_ckan_solr_host: datagov-solr1p-v2.prod-ocsit.bsp.gsa.gov

--- a/ansible/inventories/production/host_vars/catalogweb2p.prod-ocsit.bsp.gsa.gov/vars.yml
+++ b/ansible/inventories/production/host_vars/catalogweb2p.prod-ocsit.bsp.gsa.gov/vars.yml
@@ -1,2 +1,0 @@
----
-catalog_ckan_solr_host: datagov-solr1p-v2.prod-ocsit.bsp.gsa.gov


### PR DESCRIPTION
Part of https://github.com/GSA/datagov-deploy/issues/2410

Let the group vars do their thing which is easier to maintain when web hosts are
added or removed.