### PR TITLE
[hotfix] ckan listens on port 443

### DIFF
--- a/ansible/roles/software/ckan/catalog/ckan-app/molecule/catalog-next/tests/test_default.py
+++ b/ansible/roles/software/ckan/catalog/ckan-app/molecule/catalog-next/tests/test_default.py
@@ -102,7 +102,7 @@ def test_gunicorn_conf(host):
 
 
 def test_apache_site(host):
-    f = host.file('/etc/apache2/sites-enabled/ckan.conf')
+    f = host.file('/etc/apache2/sites-enabled/ckan443.conf')
 
     assert f.exists
     assert f.user == 'root'

--- a/ansible/roles/software/ckan/catalog/ckan-app/molecule/default/tests/test_default.py
+++ b/ansible/roles/software/ckan/catalog/ckan-app/molecule/default/tests/test_default.py
@@ -99,7 +99,7 @@ def test_wsgi(host):
 
 
 def test_apache_site(host):
-    f = host.file('/etc/apache2/sites-enabled/ckan.conf')
+    f = host.file('/etc/apache2/sites-enabled/ckan443.conf')
 
     assert f.exists
     assert f.user == 'root'

--- a/ansible/roles/software/ckan/catalog/ckan-app/molecule/readwrite/tests/test_default.py
+++ b/ansible/roles/software/ckan/catalog/ckan-app/molecule/readwrite/tests/test_default.py
@@ -102,7 +102,7 @@ def test_wsgi(host):
 
 
 def test_apache_site(host):
-    f = host.file('/etc/apache2/sites-enabled/ckan.conf')
+    f = host.file('/etc/apache2/sites-enabled/ckan443.conf')
 
     assert f.exists
     assert f.user == 'root'

--- a/ansible/roles/software/ckan/catalog/ckan-app/tasks/web.yml
+++ b/ansible/roles/software/ckan/catalog/ckan-app/tasks/web.yml
@@ -56,3 +56,12 @@
     owner: root
     group: www-data
   notify: reload apache2
+
+- name: Configure ckan443.conf
+  template:
+    src: etc_apache2_sites-enabled_ckan443.conf.j2
+    dest: /etc/apache2/sites-enabled/ckan443.conf
+    mode: 0644
+    owner: root
+    group: www-data
+  notify: reload apache2

--- a/ansible/roles/software/ckan/catalog/ckan-app/templates/etc_apache2_sites-enabled_ckan.conf.j2
+++ b/ansible/roles/software/ckan/catalog/ckan-app/templates/etc_apache2_sites-enabled_ckan.conf.j2
@@ -1,8 +1,3 @@
-<VirtualHost 0.0.0.0:443>
-# TODO https://github.com/GSA/datagov-deploy/issues/570
-SSLEngine on
-</VirtualHost>
-
 <VirtualHost 0.0.0.0:80>
   ServerName ckan
   Redirect 404 /

--- a/ansible/roles/software/ckan/catalog/ckan-app/templates/etc_apache2_sites-enabled_ckan443.conf.j2
+++ b/ansible/roles/software/ckan/catalog/ckan-app/templates/etc_apache2_sites-enabled_ckan443.conf.j2
@@ -1,0 +1,94 @@
+<VirtualHost 0.0.0.0:443>
+# TODO https://github.com/GSA/datagov-deploy/issues/570
+SSLEngine on
+</VirtualHost>
+
+<VirtualHost 0.0.0.0:80>
+  ServerName ckan
+  Redirect 404 /
+
+  ErrorLog {{ catalog_ckan_error_log }}
+  CustomLog {{ catalog_ckan_access_log }} combined
+</VirtualHost>
+
+<VirtualHost 0.0.0.0:80>
+  ServerName {{ catalog_ckan_apache_server_name }}
+  ServerAlias {{ catalog_ckan_apache_server_alias | join(' ') }} {{ ansible_fqdn }} localhost {{ ansible_default_ipv4.address | default('') }}
+
+  # CSW endpoints provided by pycsw
+  # full CSW, all metadata
+  ProxyPass /csw-all http://localhost:8001
+  # default CSW, collection level metadata
+  ProxyPass /csw http://localhost:8000
+
+  {% if ckan_uses_gunicorn %}
+    # gunicorn configuration
+    ProxyPass / http://localhost:5000/
+    ProxyPassReverse / http://localhost:5000/
+    ProxyPreserveHost On
+    RequestHeader set X-Forwarded-Proto https
+  {% else %}
+    WSGIScriptAlias / /etc/ckan/apache.wsgi
+
+    # Pass authorization info on (needed for rest api).
+    WSGIPassAuthorization On
+
+    # Deploy as a daemon (avoids conflicts between CKAN instances).
+    WSGIDaemonProcess ckan display-name=ckan processes={{ catalog_ckan_wsgi_processes }} threads=15
+    WSGIProcessGroup ckan
+  {% endif %}
+
+    <Directory /etc/ckan>
+      Options All
+      AllowOverride All
+      Require all granted
+    </Directory>
+
+    ErrorLog {{ catalog_ckan_error_log }}
+    CustomLog {{ catalog_ckan_access_log }} combined
+
+    # fix Cross-Frame Scripting (XFS) vulnerability
+    Header set X-Frame-Options "SAMEORIGIN"
+
+    Header set X-XSS-Protection "1; mode=block"
+    Header set X-Content-Type-Options "nosniff"
+
+    Header set Access-Control-Allow-Origin "*"
+    Header set Access-Control-Allow-Methods "POST, PUT, GET, DELETE, OPTIONS"
+    Header set Access-Control-Allow-Headers "X-CKAN-API-KEY, Authorization, Content-Type"
+
+    Header set Referrer-Policy "origin"
+
+    # Header set Content-Security-Policy "default-src 'self'"
+
+    RewriteEngine On
+
+{% if catalog_ckan_readwrite_configuration == 'readwrite' %}
+    {# Allow login, redirect any unauthed requests to the readonly site #}
+    RewriteCond %{REQUEST_URI}     !^/api/action/status_show
+    RewriteCond %{REQUEST_URI}     !^/user/(login|logged_in|_logout|logged_out|logged_out_redirect)
+    RewriteCond %{REQUEST_URI}     !^/login_generic
+    RewriteCond %{REQUEST_URI}     !^/_tracking
+    RewriteCond %{HTTP_REFERER}    !{{saml2_idp_entry}} [NC]
+    RewriteCond %{HTTP_COOKIE}     !auth_tkt
+    RewriteRule ^(.*)$ {{ url_readonly }}$1 [R,L]
+{% elif catalog_ckan_readwrite_configuration == 'readonly' %}
+    RewriteRule   "^(/en)?/user/login"  "{{ url_writable }}/user/login" [R,L]
+    RewriteRule   "^(/en)?/user/_logout"  "{{ url_writable }}/user/_logout"  [R,L]
+    RewriteRule   "^(/en)?/user/logged_in"  "{{ url_writable }}/user/logged_in"  [R,L]
+    RewriteRule   "^(/en)?/login_generic"  "{{ url_writable }}/login_generic"  [R,L]
+{% endif %}
+
+    RewriteRule ^/api/rest/dataset$ api/action/package_search [R]
+    RewriteRule ^/api/1/rest/dataset$ api/3/action/package_search [R]
+    RewriteRule ^/api/2/rest/dataset$ api/3/action/package_search [R]
+
+    RewriteRule ^/api/action/package_list$ api/action/package_search [R]
+    RewriteRule ^/api/3/action/package_list$ api/3/action/package_search [R]
+
+    RewriteRule ^/api/action/current_package_list_with_resources$ api/action/package_search [R]
+    RewriteRule ^/api/3/action/current_package_list_with_resources$ api/3/action/package_search [R]
+
+    RewriteRule ^/api/3/action/resource_search$ api/action/package_search [R]
+    RewriteRule ^/api/action/resource_search$ api/action/package_search [R]
+</VirtualHost>

--- a/ansible/roles/software/ckan/catalog/ckan-app/templates/etc_apache2_sites-enabled_ckan443.conf.j2
+++ b/ansible/roles/software/ckan/catalog/ckan-app/templates/etc_apache2_sites-enabled_ckan443.conf.j2
@@ -1,9 +1,6 @@
 <VirtualHost 0.0.0.0:443>
-# TODO https://github.com/GSA/datagov-deploy/issues/570
-SSLEngine on
-</VirtualHost>
+  SSLEngine on
 
-<VirtualHost 0.0.0.0:80>
   ServerName ckan
   Redirect 404 /
 
@@ -11,7 +8,9 @@ SSLEngine on
   CustomLog {{ catalog_ckan_access_log }} combined
 </VirtualHost>
 
-<VirtualHost 0.0.0.0:80>
+<VirtualHost 0.0.0.0:443>
+  SSLEngine on
+
   ServerName {{ catalog_ckan_apache_server_name }}
   ServerAlias {{ catalog_ckan_apache_server_alias | join(' ') }} {{ ansible_fqdn }} localhost {{ ansible_default_ipv4.address | default('') }}
 
@@ -34,8 +33,8 @@ SSLEngine on
     WSGIPassAuthorization On
 
     # Deploy as a daemon (avoids conflicts between CKAN instances).
-    WSGIDaemonProcess ckan display-name=ckan processes={{ catalog_ckan_wsgi_processes }} threads=15
-    WSGIProcessGroup ckan
+    WSGIDaemonProcess ckan443 display-name=ckan443 processes={{ catalog_ckan_wsgi_processes }} threads=15
+    WSGIProcessGroup ckan443
   {% endif %}
 
     <Directory /etc/ckan>

--- a/ansible/roles/software/ckan/inventory/molecule/default/tests/test_default.py
+++ b/ansible/roles/software/ckan/inventory/molecule/default/tests/test_default.py
@@ -16,7 +16,7 @@ def test_hosts_file(host):
 
 
 def test_apache2_sites(host):
-    ckan = host.file('/etc/apache2/sites-enabled/ckan.conf')
+    ckan = host.file('/etc/apache2/sites-enabled/ckan443.conf')
     datapusher = host.file('/etc/apache2/sites-enabled/datapusher.conf')
 
     assert ckan.exists

--- a/ansible/roles/software/ckan/inventory/tasks/main.yml
+++ b/ansible/roles/software/ckan/inventory/tasks/main.yml
@@ -99,6 +99,7 @@
   with_items:
     - etc/ckan/production.ini
     - etc/apache2/sites-enabled/ckan.conf
+    - etc/apache2/sites-enabled/ckan443.conf
   notify:
     - restart apache2
     - restart ckan

--- a/ansible/roles/software/ckan/inventory/templates/etc/apache2/sites-enabled/ckan.conf
+++ b/ansible/roles/software/ckan/inventory/templates/etc/apache2/sites-enabled/ckan.conf
@@ -1,8 +1,3 @@
-<VirtualHost 0.0.0.0:443>
-# TODO https://github.com/GSA/datagov-deploy/issues/570
-SSLEngine on
-</VirtualHost>
-
 WSGISocketPrefix /var/run/wsgi
 <VirtualHost 0.0.0.0:80>
 

--- a/ansible/roles/software/ckan/inventory/templates/etc/apache2/sites-enabled/ckan443.conf
+++ b/ansible/roles/software/ckan/inventory/templates/etc/apache2/sites-enabled/ckan443.conf
@@ -1,10 +1,6 @@
-<VirtualHost 0.0.0.0:443>
-# TODO https://github.com/GSA/datagov-deploy/issues/570
-SSLEngine on
-</VirtualHost>
-
 WSGISocketPrefix /var/run/wsgi
-<VirtualHost 0.0.0.0:80>
+<VirtualHost 0.0.0.0:443>
+    SSLEngine on
 
     ServerName ckan
 

--- a/ansible/roles/software/ckan/inventory/templates/etc/apache2/sites-enabled/ckan443.conf
+++ b/ansible/roles/software/ckan/inventory/templates/etc/apache2/sites-enabled/ckan443.conf
@@ -1,0 +1,72 @@
+<VirtualHost 0.0.0.0:443>
+# TODO https://github.com/GSA/datagov-deploy/issues/570
+SSLEngine on
+</VirtualHost>
+
+WSGISocketPrefix /var/run/wsgi
+<VirtualHost 0.0.0.0:80>
+
+    ServerName ckan
+
+    #gunicorn configuration
+    ProxyPreserveHost On
+    ProxyPass / http://127.0.0.1:5000/ retry=1
+    ProxyPassReverse / http://127.0.0.1:5000/
+
+
+    # fix Cross-Frame Scripting (XFS) vulnerability
+    Header add X-Frame-Options "SAMEORIGIN"
+
+    Header add Cache-Control "max-age=0, no-cache, no-store, must-revalidate"
+    Header add Pragma "no-cache"
+    Header add Expires "-1"
+    Header add X-XSS-Protection "1; mode=block"
+    Header add X-Content-Type-Options "nosniff"
+
+    Header add Access-Control-Allow-Origin "*"
+    Header add Access-Control-Allow-Methods "POST, PUT, GET, DELETE, OPTIONS"
+    Header add Access-Control-Allow-Headers "X-CKAN-API-KEY, Authorization, Content-Type"
+
+    Header add Referrer-Policy "origin"
+
+    # Header add Content-Security-Policy "default-src 'self'"
+
+    ErrorLog {{ inventory_ckan_error_log }}
+    CustomLog {{ inventory_ckan_access_log }} combined
+
+    <Directory /etc/ckan>
+      Options All
+      AllowOverride All
+      Require all granted
+    </Directory>
+
+    RewriteEngine On
+    RewriteCond %{HTTP_REFERER} !^https://.*\.max\.gov [NC]
+    RewriteRule ^/$ /dataset [R]
+
+    # redirect to login page except resource and api
+    RewriteCond %{HTTP_REFERER} !^https://.*\.max\.gov [NC]
+    # allow requests with an API key to hit CKAN
+    RewriteCond %{HTTP:X-CKAN-API-KEY} !^$
+    RewriteCond %{HTTP:Authorization} !^$
+    RewriteCond %{HTTP:Cookie} !.*auth_tkt=.*
+    RewriteCond %{REMOTE_ADDR} !^127\.0\.0\.1
+    RewriteCond %{REQUEST_URI} !^/user/
+    RewriteCond %{REQUEST_URI} !^/login_generic
+    RewriteCond %{REQUEST_URI} !^/fanstatic/
+    RewriteCond %{REQUEST_URI} !^/base/
+
+    RewriteCond %{REQUEST_URI} !^/dataset/[^/]+/resource/
+    RewriteCond %{REQUEST_URI} !^/api/action/datastore_search
+    RewriteCond %{REQUEST_URI} !^/api/3/action/datastore_search
+    RewriteCond %{REQUEST_URI} !^/api/action/datastore_create
+    RewriteCond %{REQUEST_URI} !^/api/3/action/datastore_create
+    RewriteCond %{REQUEST_URI} !^/api/action/member_list
+    RewriteCond %{REQUEST_URI} !^/api/3/action/member_list
+    RewriteCond %{REQUEST_URI} !^/api/action/status_show
+    RewriteCond %{REQUEST_URI} !^/api/i18n/en
+    RewriteCond %{REQUEST_URI} !^/api/1/util/snippet/[^/]
+
+    RewriteRule ^ /user/login [R]
+
+</VirtualHost>


### PR DESCRIPTION
First step for https://github.com/GSA/datagov-deploy/issues/570.
Copied apache config file `ckan.conf` to `ckan443.conf` and enable both 80 and 443.