### PR TITLE
Redirect tracking POST to writable URL

### DIFF
--- a/ansible/roles/software/ckan/catalog/ckan-app/templates/etc_apache2_sites-enabled_ckan.conf.j2
+++ b/ansible/roles/software/ckan/catalog/ckan-app/templates/etc_apache2_sites-enabled_ckan.conf.j2
@@ -72,6 +72,7 @@
     RewriteRule   "^(/en)?/user/_logout"  "{{ url_writable }}/user/_logout"  [R,L]
     RewriteRule   "^(/en)?/user/logged_in"  "{{ url_writable }}/user/logged_in"  [R,L]
     RewriteRule   "^(/en)?/login_generic"  "{{ url_writable }}/login_generic"  [R,L]
+    RewriteRule   "^/_tracking$" "{{ url_writable }}/_tracking" [R=307,L]
 {% endif %}
 
     RewriteRule ^/api/rest/dataset$ api/action/package_search [R]

--- a/ansible/roles/software/ckan/catalog/ckan-app/templates/etc_apache2_sites-enabled_ckan443.conf.j2
+++ b/ansible/roles/software/ckan/catalog/ckan-app/templates/etc_apache2_sites-enabled_ckan443.conf.j2
@@ -76,6 +76,7 @@
     RewriteRule   "^(/en)?/user/_logout"  "{{ url_writable }}/user/_logout"  [R,L]
     RewriteRule   "^(/en)?/user/logged_in"  "{{ url_writable }}/user/logged_in"  [R,L]
     RewriteRule   "^(/en)?/login_generic"  "{{ url_writable }}/login_generic"  [R,L]
+    RewriteRule   "^/_tracking$" "{{ url_writable }}/_tracking" [R=307,L]
 {% endif %}
 
     RewriteRule ^/api/rest/dataset$ api/action/package_search [R]


### PR DESCRIPTION
Related to [datagovcatalog#20](https://github.com/GSA/ckanext-datagovcatalog/issues/20)

This PR redirects `/_tracking` POST to writable URL

Tested manually in production for catalog-next and is not working (not sure why)
We are [changing JS code](https://github.com/GSA/datagov-deploy/blob/20_fix_tracking_POST/ansible/roles/software/ckan/fix-ckan-tracking/tasks/main.yml#L5) from a task in ansible to point to the right URL.

Maybe a redirection is better than these code-changes
Note: [status 307](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/307) should preserve POST and avoid changing it to GET. We are redirecting HTTP to HTTPS with a 302 redirection which transforms the POST requests into a GET one. This GET request gives us 404 response. Maybe we also need to fix the HTTP to HTTPS redirect
