### PR TITLE
[catalog] rename readwrite to writeonly

### DIFF
--- a/ansible/inventories/production/group_vars/catalog-admin/vars.yml
+++ b/ansible/inventories/production/group_vars/catalog-admin/vars.yml
@@ -1,3 +1,3 @@
 ---
 catalog_ckan_apache_server_name: "{{ catalog_host_admin }}"
-catalog_ckan_readwrite_configuration: readwrite
+catalog_ckan_readwrite_configuration: writeonly

--- a/ansible/inventories/production/group_vars/catalog-next-web-admin/vars.yml
+++ b/ansible/inventories/production/group_vars/catalog-next-web-admin/vars.yml
@@ -3,7 +3,7 @@ datagov_in_service: false  # TODO https://github.com/GSA/datagov-ckan-multi/issu
 catalog_ckan_apache_server_alias:
   - admin-catalog.data.gov
 catalog_ckan_apache_server_name: "{{ catalog_host_admin_next }}"
-catalog_ckan_readwrite_configuration: readwrite
+catalog_ckan_readwrite_configuration: writeonly
 catalog_ckan_db_host: "{{ catalog_next_ckan_db_primary_host }}"
 catalog_ckan_solr_host: "{{ catalog_next_ckan_solr_primary_host }}"
 

--- a/ansible/inventories/staging/group_vars/catalog-admin/vars.yml
+++ b/ansible/inventories/staging/group_vars/catalog-admin/vars.yml
@@ -1,3 +1,3 @@
 ---
 catalog_ckan_apache_server_name: "{{ catalog_host_admin }}"
-catalog_ckan_readwrite_configuration: readwrite
+catalog_ckan_readwrite_configuration: writeonly

--- a/ansible/inventories/staging/group_vars/catalog-next-web-admin/vars.yml
+++ b/ansible/inventories/staging/group_vars/catalog-next-web-admin/vars.yml
@@ -1,6 +1,6 @@
 ---
 catalog_ckan_apache_server_name: "{{ catalog_host_admin_next }}"
-catalog_ckan_readwrite_configuration: readwrite
+catalog_ckan_readwrite_configuration: writeonly
 catalog_ckan_db_host: "{{ catalog_next_ckan_db_primary_host }}"
 catalog_ckan_solr_host: "{{ catalog_next_ckan_solr_primary_host }}"
 

--- a/ansible/roles/software/ckan/catalog/ckan-app/defaults/main.yml
+++ b/ansible/roles/software/ckan/catalog/ckan-app/defaults/main.yml
@@ -5,13 +5,12 @@ catalog_app_type: web  # either web or worker
 catalog_ckan_access_log: "{{ catalog_log_dir }}/ckan.access.log"
 catalog_ckan_apache_server_alias: []
 catalog_ckan_apache_server_name: ckan
-catalog_ckan_readwrite_configuration: default  # One of [default, writeonly, readonly]
-                                               # default:   stand-alone instance, handles both read and write
-                                               #            operations.
-                                               # writeonly: has a db write connection for admin, redirects to readonly
-                                               #            for non admin operations.
-                                               # readonly:  serves anonymous traffic, redirects to admin for write
-                                               #            operations.
+
+# One of [default, writeonly, readonly]
+# default: stand-alone instance, handles both read and write operations.
+# writeonly: has a db write connection for admin, redirects to readonly for non admin operations.
+# readonly: serves anonymous traffic, redirects to admin for write operations.
+catalog_ckan_readwrite_configuration: default
 catalog_ckan_app_version: master
 catalog_ckan_error_log: "{{ catalog_log_dir }}/ckan.error.log"
 catalog_ckan_harvest_fetch_process_count: 2

--- a/ansible/roles/software/ckan/catalog/ckan-app/defaults/main.yml
+++ b/ansible/roles/software/ckan/catalog/ckan-app/defaults/main.yml
@@ -5,7 +5,13 @@ catalog_app_type: web  # either web or worker
 catalog_ckan_access_log: "{{ catalog_log_dir }}/ckan.access.log"
 catalog_ckan_apache_server_alias: []
 catalog_ckan_apache_server_name: ckan
-catalog_ckan_readwrite_configuration: default  # One of [default, readwrite, readonly]
+catalog_ckan_readwrite_configuration: default  # One of [default, writeonly, readonly]
+                                               # default:   stand-alone instance, handles both read and write
+                                               #            operations.
+                                               # writeonly: has a db write connection for admin, redirects to readonly
+                                               #            for non admin operations.
+                                               # readonly:  serves anonymous traffic, redirects to admin for write
+                                               #            operations.
 catalog_ckan_app_version: master
 catalog_ckan_error_log: "{{ catalog_log_dir }}/ckan.error.log"
 catalog_ckan_harvest_fetch_process_count: 2

--- a/ansible/roles/software/ckan/catalog/ckan-app/molecule/default/tests/test_default.py
+++ b/ansible/roles/software/ckan/catalog/ckan-app/molecule/default/tests/test_default.py
@@ -116,7 +116,7 @@ def test_apache_site(host):
     assert f.contains('ServerAlias .* ckan-catalog-app-'), \
         'ServerAlias should include hostname/FQDN'
 
-    # In default configuration, there should be no redirects between readwrite
+    # In default configuration, there should be no redirects between writeonly
     # and readonly instances.
     assert not f.contains('RewriteRule.*/user/login'), \
         'Expected no rewrite rule for login URLs'

--- a/ansible/roles/software/ckan/catalog/ckan-app/molecule/readwrite/playbook.yml
+++ b/ansible/roles/software/ckan/catalog/ckan-app/molecule/readwrite/playbook.yml
@@ -4,5 +4,5 @@
   roles:
     - role: ckan-app
       catalog_ckan_email_from: no-reply@data.gov
-      catalog_ckan_readwrite_configuration: readwrite
+      catalog_ckan_readwrite_configuration: writeonly
       url_readonly: https://readonly.ckan

--- a/ansible/roles/software/ckan/catalog/ckan-app/molecule/readwrite/tests/test_default.py
+++ b/ansible/roles/software/ckan/catalog/ckan-app/molecule/readwrite/tests/test_default.py
@@ -110,11 +110,11 @@ def test_apache_site(host):
     assert f.mode == 0o644
     assert f.contains('ErrorLog /var/log/ckan/ckan.error.log')
 
-    # In readwrite configuration, ServerName is admin site, not
+    # In writeonly configuration, ServerName is admin site, not
     # public site.
     assert f.contains('Redirect 404 /')
 
-    # In readwrite configuration, redirect unauthenticated requests to the
+    # In writeonly configuration, redirect unauthenticated requests to the
     # readonly url.
     assert f.contains('RewriteRule.*%s' % readonly_url)
     assert not f.contains('RewriteCond.*!/user/login'), \

--- a/ansible/roles/software/ckan/catalog/ckan-app/templates/etc_apache2_sites-enabled_ckan.conf.j2
+++ b/ansible/roles/software/ckan/catalog/ckan-app/templates/etc_apache2_sites-enabled_ckan.conf.j2
@@ -58,7 +58,7 @@
 
     RewriteEngine On
 
-{% if catalog_ckan_readwrite_configuration == 'readwrite' %}
+{% if catalog_ckan_readwrite_configuration == 'writeonly' %}
     {# Allow login, redirect any unauthed requests to the readonly site #}
     RewriteCond %{REQUEST_URI}     !^/api/action/status_show
     RewriteCond %{REQUEST_URI}     !^/user/(login|logged_in|_logout|logged_out|logged_out_redirect)

--- a/ansible/roles/software/ckan/catalog/ckan-app/templates/etc_apache2_sites-enabled_ckan443.conf.j2
+++ b/ansible/roles/software/ckan/catalog/ckan-app/templates/etc_apache2_sites-enabled_ckan443.conf.j2
@@ -62,7 +62,7 @@
 
     RewriteEngine On
 
-{% if catalog_ckan_readwrite_configuration == 'readwrite' %}
+{% if catalog_ckan_readwrite_configuration == 'writeonly' %}
     {# Allow login, redirect any unauthed requests to the readonly site #}
     RewriteCond %{REQUEST_URI}     !^/api/action/status_show
     RewriteCond %{REQUEST_URI}     !^/user/(login|logged_in|_logout|logged_out|logged_out_redirect)


### PR DESCRIPTION
Rename readwrite to avoid confusion with default, which is truly meant as
a read-write configuration. writeonly is a special configuration that attempts
to push non-write traffic to the readonly instances.