### PR TITLE
Optimize Gunicorn

### DIFF
--- a/ansible/inventories/production/group_vars/catalog-next/vars.yml
+++ b/ansible/inventories/production/group_vars/catalog-next/vars.yml
@@ -1,7 +1,7 @@
 ---
 app_repo: https://github.com/GSA/catalog.data.gov
 catalog_ckan_app_version: master
-
+catalog_ckan_wsgi_processes: 8
 catalog_ckan_apache_server_alias:
   - catalog.data.gov
 catalog_ckan_apache_server_name: "{{ catalog_host_public_next }}"
@@ -25,10 +25,9 @@ catalog_db_name: "{{ catalog_ckan_db_name }}"
 catalog_db_pass: "{{ catalog_ckan_db_pass }}"
 catalog_db_user: "{{ catalog_ckan_db_user }}"
 
-sqlalchemy_pool_size: 15
-sqlalchemy_max_overflow: 25
-datastore_sqlalchemy_pool_size: 15
-datastore_sqlalchemy_max_overflow: 25
+# Before increasing pool_size check gunicorn workers
+# sqlalchemy_pool_size: 15
+# sqlalchemy_max_overflow: 25
 
 ckan_catalog_next: true
 ckan_instance_secret: "{{ catalog_next_ckan_instance_secret }}"

--- a/ansible/inventories/production/group_vars/catalog-next/vars.yml
+++ b/ansible/inventories/production/group_vars/catalog-next/vars.yml
@@ -25,6 +25,11 @@ catalog_db_name: "{{ catalog_ckan_db_name }}"
 catalog_db_pass: "{{ catalog_ckan_db_pass }}"
 catalog_db_user: "{{ catalog_ckan_db_user }}"
 
+sqlalchemy_pool_size: 15
+sqlalchemy_max_overflow: 25
+datastore_sqlalchemy_pool_size: 15
+datastore_sqlalchemy_max_overflow: 25
+
 ckan_catalog_next: true
 ckan_instance_secret: "{{ catalog_next_ckan_instance_secret }}"
 ckan_instance_uuid: "{{ catalog_next_ckan_instance_uuid }}"

--- a/ansible/inventories/sandbox/group_vars/all/vars.yml
+++ b/ansible/inventories/sandbox/group_vars/all/vars.yml
@@ -36,7 +36,7 @@ catalog_next_postgresql_login_user: "{{ vault_catalog_next_postgresql_login_user
 
 
 ckan_create_user_via_web: true
-
+catalog_ckan_wsgi_processes: 2
 
 # common
 common_newrelic_enabled: false

--- a/ansible/inventories/staging/group_vars/all/vars.yml
+++ b/ansible/inventories/staging/group_vars/all/vars.yml
@@ -27,6 +27,7 @@ catalog_pycsw_db_name: "{{ vault_catalog_pycsw_db_name }}"
 catalog_pycsw_db_pass: "{{ vault_catalog_pycsw_db_pass }}"
 catalog_pycsw_db_user: "{{ vault_catalog_pycsw_db_user }}"
 
+catalog_ckan_wsgi_processes: 4
 
 # catalog-next
 catalog_next_ckan_db_name: "{{ vault_catalog_next_ckan_db_name }}"

--- a/ansible/roles/software/ckan/catalog/ckan-app/defaults/main.yml
+++ b/ansible/roles/software/ckan/catalog/ckan-app/defaults/main.yml
@@ -9,7 +9,10 @@ catalog_ckan_readwrite_configuration: default  # One of [default, readwrite, rea
 catalog_ckan_app_version: master
 catalog_ckan_error_log: "{{ catalog_log_dir }}/ckan.error.log"
 catalog_ckan_harvest_fetch_process_count: 2
+
+# Gunicorn recomends to use 2 * CPUs + 1: "{{ 2 * ansible_processor_vcpus|int + 1 }}"
 catalog_ckan_wsgi_processes: 2
+
 catalog_ckan_worker_type: main_worker  # Choices: main_worker misc_worker qa_worker
 catalog_ckan_plugins_additional: []
 catalog_ckan_plugins_default:

--- a/ansible/roles/software/ckan/catalog/ckan-app/templates/catalog-next/etc_ckan_production.ini.j2
+++ b/ansible/roles/software/ckan/catalog/ckan-app/templates/catalog-next/etc_ckan_production.ini.j2
@@ -62,10 +62,13 @@ db_server = {{ catalog_ckan_db_host }}
 db_database = {{ catalog_db_name }}
 sqlalchemy.url = postgresql://%(db_user)s:%(db_pass)s@%(db_server)s/%(db_database)s
 
-sqlalchemy.pool_size = {{ sqlalchemy_pool_size | default(5) }}
-sqlalchemy.max_overflow = {{ sqlalchemy_max_overflow | default(10) }}
-ckan.datastore.sqlalchemy.pool_size = {{ datastore_sqlalchemy_pool_size | default(5) }}
-ckan.datastore.sqlalchemy.max_overflow = {{ datastore_sqlalchemy_max_overflow | default(10) }}
+{% if sqlalchemy_pool_size is defined %}
+sqlalchemy.pool_size = {{ sqlalchemy_pool_size }}
+{% endif %}
+
+{% if sqlalchemy_max_overflow is defined %}
+sqlalchemy.max_overflow = {{ sqlalchemy_max_overflow }}
+{% endif %}
 
 ## Site Settings
 

--- a/ansible/roles/software/ckan/catalog/ckan-app/templates/catalog-next/etc_ckan_production.ini.j2
+++ b/ansible/roles/software/ckan/catalog/ckan-app/templates/catalog-next/etc_ckan_production.ini.j2
@@ -62,6 +62,10 @@ db_server = {{ catalog_ckan_db_host }}
 db_database = {{ catalog_db_name }}
 sqlalchemy.url = postgresql://%(db_user)s:%(db_pass)s@%(db_server)s/%(db_database)s
 
+sqlalchemy.pool_size = {{ sqlalchemy_pool_size | default(5) }}
+sqlalchemy.max_overflow = {{ sqlalchemy_max_overflow | default(10) }}
+ckan.datastore.sqlalchemy.pool_size = {{ datastore_sqlalchemy_pool_size | default(5) }}
+ckan.datastore.sqlalchemy.max_overflow = {{ datastore_sqlalchemy_max_overflow | default(10) }}
 
 ## Site Settings
 

--- a/ansible/roles/software/ckan/catalog/ckan-app/templates/supervisord_gunicorn.conf.j2
+++ b/ansible/roles/software/ckan/catalog/ckan-app/templates/supervisord_gunicorn.conf.j2
@@ -1,5 +1,5 @@
 [program:catalog-web]
-command=/etc/ckan/server_start.sh -b localhost:5000 --proxy-allow-from="127.0.0.1"
+command=/etc/ckan/server_start.sh -b localhost:5000 --workers={{ catalog_ckan_wsgi_processes }} --proxy-allow-from="127.0.0.1"
 directory={{ project_source_new_code_path }}
 stdout_logfile={{ catalog_gunicorn_error_log }}
 autostart=true


### PR DESCRIPTION
Related to [Multi#513](https://github.com/GSA/datagov-ckan-multi/issues/513)

This PR:
 - Define properly the number of workers for Gunicorn (after a load testing failed)
 - Allows set the size of sqlalchemy pools. Not in use but ready to use in the future if needed.