### PR TITLE
Add solr as search backend for spatial

### DIFF
--- a/ansible/roles/software/ckan/catalog/ckan-app/templates/catalog-next/etc_ckan_production.ini.j2
+++ b/ansible/roles/software/ckan/catalog/ckan-app/templates/catalog-next/etc_ckan_production.ini.j2
@@ -200,6 +200,9 @@ smtp.mail_from = {{ catalog_ckan_email_from }}
 ckan.tracking_enabled = True
 set debug = False
 
+## Spatial settings
+ckanext.spatial.search_backend = solr
+
 ## Harvest settings
 # ckanext-harvest will use ckan.redis.url if redis configuration
 # is not specified here.


### PR DESCRIPTION
Related to [Multi#523](https://github.com/GSA/datagov-ckan-multi/issues/523)
Require [this PR](https://github.com/GSA/datagov-deploy-solr/pull/22) to be merged (SOLR fields added)

This PR:
 - Add SOLR as search backend for spatial searches.
