### PR TITLE
Update Solr role with new field for geo search

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -67,7 +67,7 @@
   version: v1.0.2
 - name: gsa.datagov-deploy-solr
   src: https://github.com/GSA/datagov-deploy-solr.git
-  version: v1.2.0
+  version: v1.2.1
 - name: gsa.datagov-deploy-wordpress
   src: https://github.com/GSA/datagov-deploy-wordpress.git
   version: v1.0.7


### PR DESCRIPTION
Related to [Multi#523](https://github.com/GSA/datagov-ckan-multi/issues/523)

The deploy continue deploying old `schama.xml` for catalog-next (we already [added new fields](https://github.com/GSA/datagov-deploy-solr/commit/892d1ecdfc96c92e5fccde5834739dbfa8fd9f69) in `master`)

## Important
**Before merging this PR** we need to add the tag `v1.2.1` to the [Solr repo](https://github.com/GSA/datagov-deploy-solr/commit/892d1ecdfc96c92e5fccde5834739dbfa8fd9f69)