### PR TITLE
[catalog-next] add max-requests

### DIFF
--- a/ansible/roles/software/ckan/catalog/ckan-app/defaults/main.yml
+++ b/ansible/roles/software/ckan/catalog/ckan-app/defaults/main.yml
@@ -17,6 +17,8 @@ catalog_ckan_harvest_fetch_process_count: 2
 
 # Gunicorn recomends to use 2 * CPUs + 1: "{{ 2 * ansible_processor_vcpus|int + 1 }}"
 catalog_ckan_wsgi_processes: 2
+catalog_ckan_wsgi_max_requests: 5000
+catalog_ckan_wsgi_max_requests_jitter: 1000
 
 catalog_ckan_worker_type: main_worker  # Choices: main_worker misc_worker qa_worker
 catalog_ckan_plugins_additional: []

--- a/ansible/roles/software/ckan/catalog/ckan-app/templates/supervisord_gunicorn.conf.j2
+++ b/ansible/roles/software/ckan/catalog/ckan-app/templates/supervisord_gunicorn.conf.j2
@@ -1,5 +1,5 @@
 [program:catalog-web]
-command=/etc/ckan/server_start.sh -b localhost:5000 --workers={{ catalog_ckan_wsgi_processes }} --proxy-allow-from="127.0.0.1"
+command=/etc/ckan/server_start.sh -b localhost:5000 --workers={{ catalog_ckan_wsgi_processes }} --max-requests {{ catalog_ckan_wsgi_max_requests }} --max-requests-jitter {{ catalog_ckan_wsgi_max_requests_jitter }} --proxy-allow-from="127.0.0.1"
 directory={{ project_source_new_code_path }}
 stdout_logfile={{ catalog_gunicorn_error_log }}
 autostart=true


### PR DESCRIPTION
https://github.com/GSA/datagov-deploy/issues/2553

Recycle gunicorn workers every 5000-6000 requests. These numbers are a rough
guess to start. Previously this is unset, so workers are never recycled.

Assuming we want to recycle processes every ~60 minutes, with a total,
consistent site load of 2000 req/min and 4 web instances each with 6 processes
(on production):

    60m * 2000r/m / (4*6) = 5000r

And then we use a 20% jitter to stagger restarts, effectively restarting every
60-72 minutes assuming the load never changes.