### PR TITLE
[catalog] rename crontab

### DIFF
--- a/ansible/roles/software/ckan/catalog/ckan-app/files/etc/cron.d/ckan_misc_worker
+++ b/ansible/roles/software/ckan/catalog/ckan-app/files/etc/cron.d/ckan_misc_worker
@@ -1,7 +1,6 @@
 @monthly root supervisorctl start ckan-metrics-csv > /dev/null
 
 #1 1 * * * root supervisorctl start ckan-clean-deleted
-#30 2 * * * root supervisorctl start ckan-clean-harvest-logs
 #1 3 * * * root supervisorctl start ckan-tracking-update > /dev/null
 #30 23 * * * root supervisorctl start qa-update-sel:*
 #30 7 * * * root supervisorctl stop qa-update-sel:*

--- a/ansible/roles/software/ckan/catalog/ckan-app/tasks/worker.yml
+++ b/ansible/roles/software/ckan/catalog/ckan-app/tasks/worker.yml
@@ -31,7 +31,7 @@
 - name: schedule ckan-clean-harvest-logs cron
   cron:
     name: "clean harvest logs in db"
-    cron_file: ckan
+    cron_file: ckan_jobs  # Preferred location for new cron jobs. Avoid name collision with the old crontab below.
     job: supervisorctl start ckan-clean-harvest-logs > /dev/null
     minute: "30"
     hour: "2"


### PR DESCRIPTION
https://github.com/GSA/datagov-ckan-multi/issues/453

Avoid the name collision with the "legacy" /etc/cron.d/ckan file, which will
be overwritten in the next task.