### PR TITLE
disable /data.json by removing datajson from plugins

### DIFF
--- a/ansible/group_vars/catalog-next/vars.yml
+++ b/ansible/group_vars/catalog-next/vars.yml
@@ -19,7 +19,6 @@ catalog_ckan_plugins_default:
   - datagov_harvest
   - ckan_harvester
   - geodatagov
-  - datajson
   - datajson_harvest
   - geodatagov_miscs
   - z3950_harvester

--- a/ansible/roles/software/ckan/catalog/ckan-app/molecule/catalog-next/molecule.yml
+++ b/ansible/roles/software/ckan/catalog/ckan-app/molecule/catalog-next/molecule.yml
@@ -101,7 +101,6 @@ provisioner:
           - recline_view
           - harvest
           - geodatagov
-          - datajson
           - datajson_harvest
           - geodatagov_miscs
           - z3950_harvester

--- a/ansible/roles/software/ckan/catalog/ckan-app/molecule/catalog-next/tests/test_default.py
+++ b/ansible/roles/software/ckan/catalog/ckan-app/molecule/catalog-next/tests/test_default.py
@@ -53,7 +53,7 @@ def test_production_ini(host):
     assert production_ini.group == 'www-data'
     assert production_ini.mode == 0o640
 
-    assert production_ini.contains('ckan.plugins =.*datajson')
+    assert production_ini.contains('ckan.plugins =.*datajson_harvest')
     assert production_ini.contains('ckan.plugins =.*saml2')
 
 

--- a/ansible/roles/software/ckan/catalog/ckan-app/molecule/readwrite/tests/test_default.py
+++ b/ansible/roles/software/ckan/catalog/ckan-app/molecule/readwrite/tests/test_default.py
@@ -54,7 +54,7 @@ def test_production_ini(host):
     assert production_ini.group == 'www-data'
     assert production_ini.mode == 0o640
 
-    assert production_ini.contains('ckan.plugins =.*datajson')
+    assert production_ini.contains('ckan.plugins =.*datajson_harvest')
     assert not production_ini.contains('ckan.plugins =.*saml2')
 
 

--- a/ansible/roles/software/ckan/catalog/ckan-app/molecule/worker-next/molecule.yml
+++ b/ansible/roles/software/ckan/catalog/ckan-app/molecule/worker-next/molecule.yml
@@ -39,7 +39,6 @@ provisioner:
           - recline_view
           - harvest
           - geodatagov
-          - datajson
           - datajson_harvest
           - geodatagov_miscs
           - z3950_harvester


### PR DESCRIPTION
For https://github.com/GSA/datagov-deploy/issues/2581.

Requests to `/data.json` will consume too much memory, causing OOM and bring down the server. We only need `datajson_harvest` as plugin, no need for `datajson`.