### PR TITLE
[hotfix] disable datajson on catalog-next

### DIFF
--- a/ansible/group_vars/catalog-next/vars.yml
+++ b/ansible/group_vars/catalog-next/vars.yml
@@ -19,7 +19,6 @@ catalog_ckan_plugins_default:
   - datagov_harvest
   - ckan_harvester
   - geodatagov
-  - datajson
   - datajson_harvest
   - geodatagov_miscs
   - z3950_harvester

--- a/ansible/roles/software/ckan/catalog/ckan-app/molecule/catalog-next/molecule.yml
+++ b/ansible/roles/software/ckan/catalog/ckan-app/molecule/catalog-next/molecule.yml
@@ -101,7 +101,6 @@ provisioner:
           - recline_view
           - harvest
           - geodatagov
-          - datajson
           - datajson_harvest
           - geodatagov_miscs
           - z3950_harvester

--- a/ansible/roles/software/ckan/catalog/ckan-app/molecule/catalog-next/tests/test_default.py
+++ b/ansible/roles/software/ckan/catalog/ckan-app/molecule/catalog-next/tests/test_default.py
@@ -53,7 +53,7 @@ def test_production_ini(host):
     assert production_ini.group == 'www-data'
     assert production_ini.mode == 0o640
 
-    assert production_ini.contains('ckan.plugins =.*datajson')
+    assert production_ini.contains('ckan.plugins =.*datajson_harvest')
     assert production_ini.contains('ckan.plugins =.*saml2')
 
 

--- a/ansible/roles/software/ckan/catalog/ckan-app/molecule/readwrite/tests/test_default.py
+++ b/ansible/roles/software/ckan/catalog/ckan-app/molecule/readwrite/tests/test_default.py
@@ -54,7 +54,7 @@ def test_production_ini(host):
     assert production_ini.group == 'www-data'
     assert production_ini.mode == 0o640
 
-    assert production_ini.contains('ckan.plugins =.*datajson')
+    assert production_ini.contains('ckan.plugins =.*datajson_harvest')
     assert not production_ini.contains('ckan.plugins =.*saml2')
 
 

--- a/ansible/roles/software/ckan/catalog/ckan-app/molecule/worker-next/molecule.yml
+++ b/ansible/roles/software/ckan/catalog/ckan-app/molecule/worker-next/molecule.yml
@@ -39,7 +39,6 @@ provisioner:
           - recline_view
           - harvest
           - geodatagov
-          - datajson
           - datajson_harvest
           - geodatagov_miscs
           - z3950_harvester

--- a/ansible/roles/software/ckan/inventory/defaults/main.yml
+++ b/ansible/roles/software/ckan/inventory/defaults/main.yml
@@ -34,6 +34,9 @@ inventory_datapusher_error_log: "{{ inventory_log_dir }}/datapusher.error.log"
 inventory_datapusher_access_log: "{{ inventory_log_dir }}/datapusher.access.log"
 inventory_gunicorn_error_log: "{{ inventory_log_dir }}/gunicorn.log"
 
+inventory_ckan_wsgi_max_requests: 5000
+inventory_ckan_wsgi_max_requests_jitter: 1000
+
 datapusher_build_pkg_name: datapusher
 datapusher_build_pkg_branch: datagov/inventory-classic
 datapusher_build_pkg_repo: https://github.com/GSA/datapusher

--- a/ansible/roles/software/ckan/inventory/templates/etc/supervisor/conf.d/gunicorn-web-app-next.conf
+++ b/ansible/roles/software/ckan/inventory/templates/etc/supervisor/conf.d/gunicorn-web-app-next.conf
@@ -1,5 +1,5 @@
 [program:ckan]
-command=/etc/ckan/server_start.sh -b localhost:5000 --proxy-allow-from="127.0.0.1"
+command=/etc/ckan/server_start.sh -b localhost:5000 --proxy-allow-from="127.0.0.1" --max-requests {{ inventory_ckan_wsgi_max_requests }} --max-requests-jitter {{ inventory_ckan_wsgi_max_requests_jitter }}
 directory={{ project_source_new_code_path }}
 user=www-data
 group=www-data


### PR DESCRIPTION
https://github.com/GSA/datagov-deploy/issues/2581

Promotes https://github.com/GSA/datagov-deploy/pull/2585 to hotfix.

datajson provides a data.json file for organizations. This is meant for an
Inventory configuration and does not scale to catalog.data.gov. Disable it for
now.

This includes the max-requests change for Inventory, but including that in the
hotfix is an acceptable risk.