### PR TITLE
[catalog] obey newrelic_enabled

### DIFF
--- a/ansible/roles/software/ckan/catalog/ckan-app/templates/gunicorn_env.j2
+++ b/ansible/roles/software/ckan/catalog/ckan-app/templates/gunicorn_env.j2
@@ -1,6 +1,6 @@
 NEW_RELIC_LICENSE_KEY="{{ newrelic_license_key }}"
 NEW_RELIC_APP_NAME="{{ newrelic_app_name }}"
-NEW_RELIC_MONITOR_MODE=true
+NEW_RELIC_MONITOR_MODE={{ newrelic_enabled | ternary('true', 'false') }}
 NEW_RELIC_LOG=/var/log/new_relic.log
 NEW_RELIC_LOG_LEVEL=info
 NEW_RELIC_HOST=gov-collector.newrelic.com

--- a/ansible/roles/software/ckan/catalog/ckan-app/templates/gunicorn_env.j2
+++ b/ansible/roles/software/ckan/catalog/ckan-app/templates/gunicorn_env.j2
@@ -1,5 +1,5 @@
 NEW_RELIC_LICENSE_KEY="{{ newrelic_license_key }}"
-NEW_RELIC_APP_NAME="{{ newrelic_app_name }}"
+NEW_RELIC_APP_NAME="{{ newrelic_app_name }}{% if newrelic_environment != 'production' %} ({{ newrelic_environment }}){% endif %}"
 NEW_RELIC_MONITOR_MODE={{ newrelic_enabled | ternary('true', 'false') }}
 NEW_RELIC_LOG=/var/log/new_relic.log
 NEW_RELIC_LOG_LEVEL=info


### PR DESCRIPTION
New Relic should only be enabled for production and staging environments.