### PR TITLE
[jenkins] use LTS version

### DIFF
--- a/ansible/group_vars/all/vars.yml
+++ b/ansible/group_vars/all/vars.yml
@@ -147,6 +147,7 @@ jenkins_jobs:
     git_url: https://github.com/gsa/datagov-wp-boilerplate.git
 jenkins_additional_plugins:
   - build-token-root  # Allow CircleCI to trigger builds with a job token
+jenkins_prefer_tls: true  # Use long-term-support releases instead of weekly updates
 
 
 # Limit SSH Access


### PR DESCRIPTION
Avoid bugs and instability from weekly builds. Stick to the LTS builds.

With Jenkins 2.274, we started seeing our [GH issues](https://github.com/GSA/datagov-ckan-multi/issues/545) without the template rendering. We should be sticking to stable builds for Jenkins.