### PR TITLE
Fix who.ini to fit CKAN requirements

### DIFF
--- a/ansible/roles/software/ckan/catalog/ckan-app/templates/catalog-next/etc_ckan_who.saml2.ini.j2
+++ b/ansible/roles/software/ckan/catalog/ckan-app/templates/catalog-next/etc_ckan_who.saml2.ini.j2
@@ -2,6 +2,17 @@
 use = repoze.who.plugins.auth_tkt:make_plugin
 secret = {{ catalog_ckan_who_ini_secret }}
 
+[plugin:friendlyform]
+use = repoze.who.plugins.friendlyform:FriendlyFormPlugin
+login_form_url= /user/login
+login_handler_path = /login_generic
+logout_handler_path = /user/logout
+rememberer_name = auth_tkt
+post_login_url = /user/logged_in
+post_logout_url = /user/logged_out
+charset = utf-8
+
+
 [general]
 request_classifier = repoze.who.classifiers:default_request_classifier
 challenge_decider = repoze.who.classifiers:default_challenge_decider
@@ -9,7 +20,12 @@ challenge_decider = repoze.who.classifiers:default_challenge_decider
 [identifiers]
 plugins =
     auth_tkt
+    friendlyform;browser
 
 [authenticators]
 plugins =
     auth_tkt
+
+[challengers]
+plugins =
+    friendlyform;browser


### PR DESCRIPTION
CKAN 2.8 requires `friendlyform` even if we don't use it