### PR TITLE
[pycsw] use application db user

### DIFF
--- a/ansible/inventories/sandbox/group_vars/pycsw-web-v2/vars.yml
+++ b/ansible/inventories/sandbox/group_vars/pycsw-web-v2/vars.yml
@@ -5,6 +5,3 @@ pycsw_base_url: https://catalog-next.sandbox.datagov.us
 pycsw_ckan_url: https://catalog-next.sandbox.datagov.us
 
 pycsw_db_host: "{{ catalog_next_postgresql_login_host }}"
-pycsw_db_name: pycsw
-pycsw_db_password: "{{ catalog_next_postgresql_login_password }}"
-pycsw_db_user: "{{ catalog_next_postgresql_login_user }}"

--- a/ansible/inventories/sandbox/group_vars/pycsw-worker-v2/vars.yml
+++ b/ansible/inventories/sandbox/group_vars/pycsw-worker-v2/vars.yml
@@ -5,6 +5,3 @@ pycsw_base_url: https://catalog-next.sandbox.datagov.us
 pycsw_ckan_url: https://catalog-next.sandbox.datagov.us
 
 pycsw_db_host: "{{ catalog_next_postgresql_login_host }}"
-pycsw_db_name: pycsw
-pycsw_db_password: "{{ catalog_next_postgresql_login_password }}"
-pycsw_db_user: "{{ catalog_next_postgresql_login_user }}"


### PR DESCRIPTION
Use the pycsw db user with the existing pycsw password instead of using the
db administrator account.

After reseting the catalog-next database, the pyscw deploy fails on the smoke
test (https://github.com/GSA/datagov-deploy/issues/2626#issuecomment-756931121) because the database doesn't exist. After creating the database, the
deploy was working again, but only because it was using the admin user. This
removes those variables so we will fallback to the pycsw user/password.

DB creation looks like this from the catalog-next-web1tf host:
```
createuser -h $DB_HOST -U $DB_ADMIN_USER -S -D -R -P pycsw
psql -h $DB_HOST -U $DB_ADMIN_USER -c "GRANT pycsw to $DB_ADMIN_USER;" postgres
createdb -h $DB_HOST -U $DB_ADMIN_USER -O pycsw pycsw -E utf-8
psql -h $DB_HOST -U $DB_ADMIN_USER -d pycsw -c 'CREATE EXTENSION postgis;'
sudo su -l pycsw
cd current
. .venv/bin/activate
pycsw-ckan.py -c setup_db -f /etc/pycsw/pycsw-collection.cfg
```