### PR TITLE
[wordpress] remove wp-bsp from allowed hostnames

### DIFF
--- a/ansible/inventories/production/group_vars/all/vars.yml
+++ b/ansible/inventories/production/group_vars/all/vars.yml
@@ -83,7 +83,7 @@ products:
 
 # dashboard
 # hostname needed for smoke test, IP address needed for ALB health check
-dashboard_nginx_server_name: labs.data.gov labs-bsp.data.gov dashboard-bsp.data.gov $hostname {{ ansible_default_ipv4.address }}
+dashboard_nginx_server_name: labs.data.gov $hostname {{ ansible_default_ipv4.address }}
 dashboard_service_url: https://labs.data.gov/dashboard
 php_cli_memory_limit: 3192M
 

--- a/ansible/inventories/production/group_vars/all/vars.yml
+++ b/ansible/inventories/production/group_vars/all/vars.yml
@@ -309,5 +309,5 @@ ci_deploy_version: master
 
 # wordpress
 # hostname needed for smoke test, IP address needed for ALB health check
-wordpress_nginx_server_name: www.data.gov data.gov wp-bsp.data.gov labs.data.gov $hostname {{ ansible_default_ipv4.address }}
+wordpress_nginx_server_name: www.data.gov data.gov labs.data.gov $hostname {{ ansible_default_ipv4.address }}
 wordpress_service_url: https://www.data.gov

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -43,7 +43,7 @@
   version: 1.0.4
 - name: gsa.datagov-deploy-dashboard
   src: https://github.com/GSA/datagov-deploy-dashboard
-  version: v1.1.5
+  version: v1.1.6
 - name: gsa.datagov-deploy-apache2
   src: https://github.com/GSA/datagov-deploy-apache2
   version: v1.3.2
@@ -70,7 +70,7 @@
   version: v1.2.1
 - name: gsa.datagov-deploy-wordpress
   src: https://github.com/GSA/datagov-deploy-wordpress.git
-  version: v1.0.9
+  version: v1.0.10
 - name: jnv.unattended-upgrades
   version: v1.8.0
 - name: jobscore.beats


### PR DESCRIPTION
https://github.com/GSA/datagov-deploy/issues/2597

WP should return a 404 for wp-bsp domain instead of serving traffic. This helps
reduce load on WP and improves SEO.