### PR TITLE
Fix resource_search endpoint

### DIFF
--- a/ansible/roles/software/ckan/catalog/ckan-app/templates/etc_apache2_sites-enabled_ckan.conf.j2
+++ b/ansible/roles/software/ckan/catalog/ckan-app/templates/etc_apache2_sites-enabled_ckan.conf.j2
@@ -99,7 +99,4 @@
 
     RewriteRule ^/api/action/current_package_list_with_resources$ api/action/package_search [R]
     RewriteRule ^/api/3/action/current_package_list_with_resources$ api/3/action/package_search [R]
-
-    RewriteRule ^/api/3/action/resource_search$ api/action/package_search [R]
-    RewriteRule ^/api/action/resource_search$ api/action/package_search [R]
 </VirtualHost>


### PR DESCRIPTION
The `resource_search` API endpoint is been redirected to `package_search`
It seems this is an error and we need this endpoint to finish our[ load testing tool](https://github.com/GSA/datagov-load-testing/blob/advanced_test/locust/advanced.py#L114-L132)

The [commit](https://github.com/GSA/datagov-deploy/commit/b32de59301d5198e44e669b4eb03cb4fd8730be2) that applies this change is not clear about why. Probably a mistake.