### PR TITLE
[jenkins] support branch builds

### DIFF
--- a/ansible/group_vars/all/vars.yml
+++ b/ansible/group_vars/all/vars.yml
@@ -145,7 +145,7 @@ jenkins_jobs:
     git_ref: refs/heads/inventory_ckan_2.8
   - name: deploy-ci-app-wordpress
     git_url: https://github.com/gsa/datagov-wp-boilerplate.git
-jenkins_prefer_tls: true  # Use long-term-support releases instead of weekly updates
+jenkins_prefer_lts: true  # Use long-term-support releases instead of weekly updates
 
 
 # Limit SSH Access

--- a/ansible/group_vars/all/vars.yml
+++ b/ansible/group_vars/all/vars.yml
@@ -145,8 +145,6 @@ jenkins_jobs:
     git_ref: refs/heads/inventory_ckan_2.8
   - name: deploy-ci-app-wordpress
     git_url: https://github.com/gsa/datagov-wp-boilerplate.git
-jenkins_additional_plugins:
-  - build-token-root  # Allow CircleCI to trigger builds with a job token
 jenkins_prefer_tls: true  # Use long-term-support releases instead of weekly updates
 
 

--- a/ansible/templates/jenkins_config.yml.j2
+++ b/ansible/templates/jenkins_config.yml.j2
@@ -68,6 +68,9 @@ jobs:
 {% for job in jenkins_jobs %}
   - script: |
       pipelineJob('{{ job.name }}') {
+        parameters {
+          stringParam('branch_name', '{{ job.git_ref | default('master') }}', 'Git branch to checkout and build.')
+        }
         authenticationToken('{{ job.authentication_token | default(jenkins_job_authentication_token) }}')
         properties {
           buildDiscarder { strategy { logRotator {
@@ -89,10 +92,9 @@ jobs:
                 remote {
                   url('{{ job.git_url }}')
                 }
-                branch('{{ job.git_ref | default('refs/heads/master') }}')
+                branch('refs/heads/${branch_name}')
               }
             }
-            lightweight()
           }
         }
       }

--- a/bin/jenkins_build
+++ b/bin/jenkins_build
@@ -17,8 +17,6 @@ Environment variables are required:
 
   JENKINS_API_TOKEN the API token for the user, see \$JENKINS_URL/user/<user-name>/configure.
 
-  JENKINS_JOB_TOKEN the secret authorization token for this job, see \$JENKINS_URL/job/<job-name>/configure.
-
   JENKINS_USER the username to access the API as.
 EOF
 
@@ -33,26 +31,14 @@ function jenkins_curl () {
   curl --silent --fail --user "$JENKINS_USER:$JENKINS_API_TOKEN" "$@" "${JENKINS_URL}${url}"
 }
 
-function crumb_header () {
-  # Get a CRSF token (crumb) from Jenkins
-  local crumb_response crumb_header crumb_value
-
-  # Create a temp file for processing the response
-  crumb_response=$(mktemp)
-
-  jenkins_curl /crumbIssuer/api/json > "$crumb_response"
-  crumb_header=$(jq --raw-output .crumbRequestField "$crumb_response")
-  crumb_value=$(jq --raw-output .crumb "$crumb_response")
-  rm -rf "$crumb_response"
-  echo -n "$crumb_header:$crumb_value"
-}
-
 function build_job () {
   local job_name
   job_name=$1
 
-  jenkins_curl "/job/${job_name}/build?token=$JENKINS_JOB_TOKEN" -X POST -H "$(crumb_header)" --data "cause=${CIRCLE_BUILD_URL:-build script}"
-  echo "$job_name" started.
+  jenkins_curl "/job/${job_name}/buildWithParameters" -X POST \
+    --data "branch_name=${CIRCLE_BRANCH}" \
+    --data "cause=${CIRCLE_BUILD_URL:-build script}"
+  echo "$job_name started for branch=$CIRCLE_BRANCH."
 }
 
 
@@ -64,11 +50,6 @@ fi
 
 if [[ -z "${JENKINS_API_TOKEN:-}" ]]; then
   echo \$JENKINS_API_TOKEN is not set. >&2
-  usage
-fi
-
-if [[ -z "${JENKINS_JOB_TOKEN:-}" ]]; then
-  echo \$JENKINS_JOB_TOKEN is not set. >&2
   usage
 fi
 


### PR DESCRIPTION
https://github.com/GSA/datagov-deploy/issues/811

We've been hard-coding the branch to build per job through the Ansible
configuration. This allows the branch to be passed as a build parameter so that
staging can build both `release/*` and `master` branches.

This also makes things less confusing between CircleCI and Jenkins, where you
might be triggering a build from one branch on CircleCI but Jenkins uses
a different branch from the job configuration. This removes that quirk.