### PR TITLE
Pin pip version for python 2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,8 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v5-pipenv-{{ checksum "Pipfile.lock" }}
-            - v5-pipenv-
+            - v6-pipenv-{{ checksum "Pipfile.lock" }}
+            - v6-pipenv-
       - run: pipenv sync --dev
       - run: pipenv run make vendor
       - run: pipenv run make lint
@@ -25,8 +25,8 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v5-pipenv-{{ checksum "Pipfile.lock" }}
-            - v5-pipenv-
+            - v6-pipenv-{{ checksum "Pipfile.lock" }}
+            - v6-pipenv-
       - run: pipenv sync --dev
       - run:
           name: install snyk
@@ -40,8 +40,8 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v5-pipenv-{{ checksum "Pipfile.lock" }}
-            - v5-pipenv-
+            - v6-pipenv-{{ checksum "Pipfile.lock" }}
+            - v6-pipenv-
       - run: pipenv sync --dev
       - run:
           name: install snyk
@@ -60,8 +60,8 @@ jobs:
       # Restore cache and install python dependencies
       - restore_cache:
           keys:
-            - v5-pipenv-{{ checksum "Pipfile.lock" }}
-            - v5-pipenv-
+            - v6-pipenv-{{ checksum "Pipfile.lock" }}
+            - v6-pipenv-
       - run:
           name: install python dependencies
           command: |
@@ -71,7 +71,7 @@ jobs:
           name: Setup ansible-galaxy
           command: pipenv run make vendor
       - save_cache:
-          key: v5-pipenv-{{ checksum "Pipfile.lock" }}
+          key: v6-pipenv-{{ checksum "Pipfile.lock" }}
           paths:
             - .venv
             - ansible/roles/vendor

--- a/ansible/roles/software/ckan/catalog/ckan-app/molecule/catalog-next/tests/test_default.py
+++ b/ansible/roles/software/ckan/catalog/ckan-app/molecule/catalog-next/tests/test_default.py
@@ -81,6 +81,16 @@ def test_compatible_repoze_who(host):
     assert '1.7.5.1' == packages['Paste'].get('version')
 
 
+def test_pip_version(host):
+    # pip 21 no longer support Python 2
+    packages = host.pip_package.get_packages(
+        pip_path=('%s/bin/pip' % virtualenv_path)
+    )
+
+    assert 'pip' in packages
+    assert '20.3.3' == packages['pip'].get('version')
+
+
 def test_apache(host):
     apache = host.service('apache2')
 

--- a/ansible/roles/software/ckan/catalog/ckan-app/molecule/default/tests/test_default.py
+++ b/ansible/roles/software/ckan/catalog/ckan-app/molecule/default/tests/test_default.py
@@ -83,6 +83,7 @@ def test_compatible_repoze_who(host):
 
 
 def test_pip_version(host):
+    # pip 21 no longer support Python 2
     packages = host.pip_package.get_packages(
         pip_path=('%s/bin/pip' % virtualenv_path)
     )

--- a/ansible/roles/software/ckan/catalog/ckan-app/molecule/default/tests/test_default.py
+++ b/ansible/roles/software/ckan/catalog/ckan-app/molecule/default/tests/test_default.py
@@ -82,6 +82,15 @@ def test_compatible_repoze_who(host):
     assert '1.7.5.1' == packages['Paste'].get('version')
 
 
+def test_pip_version(host):
+    packages = host.pip_package.get_packages(
+        pip_path=('%s/bin/pip' % virtualenv_path)
+    )
+
+    assert 'pip' in packages
+    assert '20.3.3' == packages['pip'].get('version')
+
+
 def test_apache(host):
     apache = host.service('apache2')
 

--- a/ansible/roles/software/ckan/catalog/ckan-app/tasks/main.yml
+++ b/ansible/roles/software/ckan/catalog/ckan-app/tasks/main.yml
@@ -74,7 +74,7 @@
 - name: setup virtualenv for new deployment
   pip:
     name:
-      - pip>=19.3.0
+      - pip==20.3.3  # pip 21 no longer supports python 2
       - setuptools>=44.0.0,<45.0.0  # setuptools 45+ requires python 3.5, keep pinned below, but still modern version
     virtualenv: '{{ project_source_new_code_path }}'
     virtualenv_python: "{{ catalog_ckan_python_home }}/bin/python"

--- a/ansible/roles/software/ckan/inventory/tasks/main.yml
+++ b/ansible/roles/software/ckan/inventory/tasks/main.yml
@@ -58,7 +58,7 @@
 - name: setup virtualenv for new deployment
   pip:
     name:
-      - pip>=19.3.0
+      - pip==20.3.3  # pip 21 no longer supports python 2
       - setuptools>=44.0.0,<45.0.0  # setuptools 45+ requires python 3.5, keep pinned below, but still modern version
     virtualenv: '{{ project_source_new_code_path }}'
     virtualenv_python: "{{ inventory_python_home }}/bin/python"


### PR DESCRIPTION
We need to pin pip version from CKAN 2.8 because pip no longer support python 2

https://pip.pypa.io/en/stable/
![image](https://user-images.githubusercontent.com/3237309/105706829-d134ea00-5ef0-11eb-9045-701334b41903.png)
