### PR TITLE
[jenkins] fix branch builds

### DIFF
--- a/ansible/inventories/mgmt/group_vars/all/vars.yml
+++ b/ansible/inventories/mgmt/group_vars/all/vars.yml
@@ -116,7 +116,7 @@ jenkins_jobs:
     git_url: https://github.com/gsa/inventory-app.git
   - name: deploy-ci-app-inventory-next
     git_url: https://github.com/gsa/inventory-app.git
-    git_ref: refs/heads/inventory_ckan_2.8
+    git_ref: inventory_ckan_2.8
   - name: deploy-ci-app-wordpress
     git_url: https://github.com/gsa/datagov-wp-boilerplate.git
 jenkins_saml_sp_entity_id: urn:gov:gsa:SAML:2.0.profiles:sp:sso:gsa:datagov-ci-jenkins

--- a/ansible/inventories/sandbox/group_vars/all/vars.yml
+++ b/ansible/inventories/sandbox/group_vars/all/vars.yml
@@ -134,7 +134,7 @@ jenkins_job_authentication_token: "{{ vault_jenkins_job_authentication_token }}"
 jenkins_jobs:
   - name: deploy-ci-platform
     git_url: https://github.com/gsa/datagov-deploy.git
-    git_ref: refs/heads/develop
+    git_ref: develop
   - name: deploy-ci-app-catalog
     git_url: https://github.com/gsa/catalog-app.git
   - name: deploy-ci-app-catalog-next
@@ -146,7 +146,7 @@ jenkins_jobs:
     git_url: https://github.com/gsa/inventory-app.git
   - name: deploy-ci-app-inventory-next
     git_url: https://github.com/gsa/inventory-app.git
-    git_ref: refs/heads/inventory_ckan_2.8
+    git_ref: inventory_ckan_2.8
   - name: deploy-ci-app-wordpress
     git_url: https://github.com/gsa/datagov-wp-boilerplate.git
 

--- a/ansible/templates/jenkins_config.yml.j2
+++ b/ansible/templates/jenkins_config.yml.j2
@@ -92,7 +92,7 @@ jobs:
                 remote {
                   url('{{ job.git_url }}')
                 }
-                branch('refs/heads/${branch_name}')
+                branch('refs/heads/^${branch_name}')
               }
             }
           }


### PR DESCRIPTION
https://github.com/GSA/datagov-deploy/issues/2696

Two issues here:

- CircleCI is only passing branch name, not the full ref. Update branch_name parameter defaults to match.
- Job configuration is dropping the branch_name parameter (interpolated as an empty string). Escape [environment variable interpolation][1] in the configuration-as-code plugin so that the parameter makes it into the job configuration.

[1]: https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/docs/features/secrets.adoc#passing-secrets-through-variables