### PR TITLE
Add Cache-Control max-age to catalog-next

### DIFF
--- a/ansible/inventories/production/group_vars/catalog-next/vars.yml
+++ b/ansible/inventories/production/group_vars/catalog-next/vars.yml
@@ -2,6 +2,7 @@
 app_repo: https://github.com/GSA/catalog.data.gov
 catalog_ckan_app_version: master
 catalog_ckan_wsgi_processes: 8
+catalog_ckan_cache_control_max_age: 86400
 catalog_ckan_apache_server_alias:
   - catalog.data.gov
 catalog_ckan_apache_server_name: "{{ catalog_host_public_next }}"

--- a/ansible/inventories/sandbox/group_vars/catalog-next/vars.yml
+++ b/ansible/inventories/sandbox/group_vars/catalog-next/vars.yml
@@ -17,6 +17,7 @@ catalog_ckan_redis_password: "{{ catalog_next_ckan_redis_password }}"
 
 catalog_ckan_plugins_default: "{{ catalog_next_ckan_plugins_default }}"
 catalog_ckan_plugins_additional: [saml2auth]
+catalog_ckan_cache_control_max_age: 300
 
 # login.gov identity sandbox
 saml2_idp_metadata_url: "https://idp.int.identitysandbox.gov/api/saml/metadata2020"

--- a/ansible/inventories/staging/group_vars/catalog-next/vars.yml
+++ b/ansible/inventories/staging/group_vars/catalog-next/vars.yml
@@ -32,6 +32,7 @@ ckan_production_ini_template: "{{ catalog_next_ckan_production_ini_template }}"
 ckan_session_store_type: memory
 ckan_site_domain: https://catalog-next-datagov.dev-ocsit.bsp.gsa.gov
 ckan_uses_gunicorn: true
+catalog_ckan_cache_control_max_age: 86400
 
 datagov_service: catalog-next
 

--- a/ansible/roles/software/ckan/catalog/ckan-app/defaults/main.yml
+++ b/ansible/roles/software/ckan/catalog/ckan-app/defaults/main.yml
@@ -5,6 +5,7 @@ catalog_app_type: web  # either web or worker
 catalog_ckan_access_log: "{{ catalog_log_dir }}/ckan.access.log"
 catalog_ckan_apache_server_alias: []
 catalog_ckan_apache_server_name: ckan
+catalog_ckan_cache_control_max_age: 0
 
 # One of [default, writeonly, readonly]
 # default: stand-alone instance, handles both read and write operations.

--- a/ansible/roles/software/ckan/catalog/ckan-app/templates/catalog-next/etc_ckan_production.ini.j2
+++ b/ansible/roles/software/ckan/catalog/ckan-app/templates/catalog-next/etc_ckan_production.ini.j2
@@ -29,6 +29,8 @@ beaker.session.key = ckan
 
 # CKAN caching
 ckan.cache_expires = 300
+ckan.cache_enabled = true
+ckan.static_max_age = 86400
 
 # This is the secret token that the beaker library uses to hash the cookie sent
 # to the client. `paster make-config` generates a unique value for this each

--- a/ansible/roles/software/ckan/catalog/ckan-app/templates/etc_apache2_sites-enabled_ckan.conf.j2
+++ b/ansible/roles/software/ckan/catalog/ckan-app/templates/etc_apache2_sites-enabled_ckan.conf.j2
@@ -56,7 +56,7 @@
     CustomLog {{ catalog_ckan_access_log }} combined
 
     # Cache
-    Header add Cache-Control "max-age={{ catalog_ckan_cache_control_max_age }}"
+    Header set Cache-Control "max-age={{ catalog_ckan_cache_control_max_age }}"
     
     # fix Cross-Frame Scripting (XFS) vulnerability
     Header set X-Frame-Options "SAMEORIGIN"

--- a/ansible/roles/software/ckan/catalog/ckan-app/templates/etc_apache2_sites-enabled_ckan.conf.j2
+++ b/ansible/roles/software/ckan/catalog/ckan-app/templates/etc_apache2_sites-enabled_ckan.conf.j2
@@ -55,6 +55,9 @@
     ErrorLog {{ catalog_ckan_error_log }}
     CustomLog {{ catalog_ckan_access_log }} combined
 
+    # Cache
+    Header add Cache-Control "max-age={{ catalog_ckan_cache_control_max_age }}"
+    
     # fix Cross-Frame Scripting (XFS) vulnerability
     Header set X-Frame-Options "SAMEORIGIN"
 


### PR DESCRIPTION
Related to [Multi#449](https://github.com/gsa/datagov-ckan-multi/issues/449)

As mentioned in #1311 CKAN fails to handle max-age and the [fix](https://github.com/ckan/ckan/pull/4781/files) is not backported to CKAN 2.8.
Maybe we can force this in apache configuration