### PR TITLE
[solr-next] Bump the JVM max memory

### DIFF
--- a/ansible/inventories/production/group_vars/solr-next/vars.yml
+++ b/ansible/inventories/production/group_vars/solr-next/vars.yml
@@ -5,5 +5,6 @@ solr_master_server: datagov-solrm1p-v2.prod-ocsit.bsp.gsa.gov
 solr_cores:
   - catalog-next
   - inventory-next
+solr_xmx: 12288m
 
 trendmicro_policy_id: "{{ trendmicro_policy_id_app }}"


### PR DESCRIPTION
https://github.com/GSA/datagov-ckan-multi/issues/560

Solr hosts have 16G memory. Bump the JVM limit to allow solr to use more memory.
Based on tests, there's still plenty of solr capacity so this change isn't
necessary but this doesn't hurt.