### PR TITLE
[solr-next] Bump the JVM max memory

### DIFF
--- a/ansible/inventories/production/group_vars/all/vars.yml
+++ b/ansible/inventories/production/group_vars/all/vars.yml
@@ -267,7 +267,7 @@ solr_cores:
   - catalog
   - inventory
 solr_xms: 8192m
-solr_xmx: 8192m
+solr_xmx: 12288m
 
 
 

--- a/ansible/inventories/staging/group_vars/all/vars.yml
+++ b/ansible/inventories/staging/group_vars/all/vars.yml
@@ -259,7 +259,7 @@ solr_cores:
   - catalog
   - inventory
 solr_xms: 8192m
-solr_xmx: 8192m
+solr_xmx: 12288m
 
 # SecOps user
 secops_user: "{{ vault_secops_user }}"


### PR DESCRIPTION
https://github.com/GSA/datagov-ckan-multi/issues/560

Solr hosts have 16G memory. Bump the JVM limit to allow solr to use more memory.
Based on tests, there's still plenty of solr capacity so this change isn't
necessary but this doesn't hurt.