### PR TITLE
Define analytics settings for production

### DIFF
--- a/ansible/inventories/production/group_vars/catalog-next/vars.yml
+++ b/ansible/inventories/production/group_vars/catalog-next/vars.yml
@@ -27,6 +27,12 @@ catalog_db_name: "{{ catalog_ckan_db_name }}"
 catalog_db_pass: "{{ catalog_ckan_db_pass }}"
 catalog_db_user: "{{ catalog_ckan_db_user }}"
 
+googleanalytics_ids:
+  - UA-42145528-2
+  - UA-17367410-17
+googleanalytics_accout_name: GSA Data.gov
+googleanalytics_token_filepath: /etc/ckan/token.dat
+
 # Before increasing pool_size check gunicorn workers
 # sqlalchemy_pool_size: 15
 # sqlalchemy_max_overflow: 25

--- a/ansible/roles/software/ckan/catalog/ckan-app/defaults/main.yml
+++ b/ansible/roles/software/ckan/catalog/ckan-app/defaults/main.yml
@@ -59,8 +59,7 @@ catalog_enable_clean_harvest_logs: false
 catalog_log_dir: /var/log/ckan
 catalog_gunicorn_error_log: "{{ catalog_log_dir }}/gunicorn.log"
 
-googleanalytics_ids:
-  - UA-XXXXXXX-1
+googleanalytics_ids: []
 googleanalytics_accout_name: GSA Data.gov Fake analytics
 
 app_source_path: /tmp/catalog-app

--- a/ansible/roles/software/ckan/catalog/ckan-app/defaults/main.yml
+++ b/ansible/roles/software/ckan/catalog/ckan-app/defaults/main.yml
@@ -59,6 +59,9 @@ catalog_enable_clean_harvest_logs: false
 catalog_log_dir: /var/log/ckan
 catalog_gunicorn_error_log: "{{ catalog_log_dir }}/gunicorn.log"
 
+googleanalytics_ids:
+  - UA-XXXXXXX-1
+googleanalytics_accout_name: GSA Data.gov Fake analytics
 
 app_source_path: /tmp/catalog-app
 app_repo: https://github.com/GSA/catalog-app.git

--- a/ansible/roles/software/ckan/catalog/ckan-app/templates/catalog-next/etc_ckan_production.ini.j2
+++ b/ansible/roles/software/ckan/catalog/ckan-app/templates/catalog-next/etc_ckan_production.ini.j2
@@ -247,8 +247,16 @@ ckanext.saml2auth.enable_ckan_internal_login=false
 {% endif %}
 
 # Google Analytics
-googleanalytics.ids = UA-42145528-2 UA-17367410-17
-googleanalytics.id = UA-42145528-2
+{% if googleanalytics_ids | length > 0 %}
+
+googleanalytics.ids = {{ googleanalytics_ids | join(' ') }}
+googleanalytics.id = {{ googleanalytics_ids | first }}
+googleanalytics.account = {{ googleanalytics_accout_name }}
+{% if googleanalytics_token_filepath is defined %}
+googleanalytics.token.filepath = {{ googleanalytics_token_filepath | default('') }}
+{% endif %}
+
+{% endif %}
 
 # ckanext-geodatagov settings
 

--- a/ansible/roles/software/ckan/catalog/ckan-app/templates/etc_ckan_production.ini.j2
+++ b/ansible/roles/software/ckan/catalog/ckan-app/templates/etc_ckan_production.ini.j2
@@ -259,6 +259,7 @@ googleanalytics.ids = UA-42145528-2 UA-17367410-17
 googleanalytics.id = UA-42145528-2
 googleanalytics.account = GSA Data.gov
 googleanalytics.token.filepath = /etc/ckan/token.dat
+
 ga-report.period = monthly
 ga-report.bounce_url = /
 


### PR DESCRIPTION
Related to [Multi#405](https://github.com/GSA/datagov-ckan-multi/issues/405)

Define Google Analytics settings for each catalog-next environment

### To validate
Not sure about `googleanalytics.token.filepath` since is not found in analytics extension
We are using it for catalog-classic but is not clear on how it works.