### PR TITLE
[jenkins] Use default Ansible control_path

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -366,7 +366,7 @@ become_method=sudo
 # Example:
 # control_path = %(directory)s/%%h-%%r
 #control_path =
-control_path = %(directory)s/%%h-%%p-%%r
+#control_path = %(directory)s/%%h-%%p-%%r
 
 # Enabling pipelining reduces the number of SSH operations required to
 # execute a module on the remote server. This can result in a significant


### PR DESCRIPTION
We're running into the "too long for Unix domain socket" error for some hosts
with long names (catalog-next-fgdc2iso). Use the default which doesn't include
the hostname.