### PR TITLE
Use master as default branch

### DIFF
--- a/.github/ISSUE_TEMPLATE/offboard-team-member.md
+++ b/.github/ISSUE_TEMPLATE/offboard-team-member.md
@@ -19,7 +19,7 @@ These tasks are performed by an Admin unless noted as an action for the outgoing
 - [ ] Remove team member from [GCP account](https://console.cloud.google.com/iam-admin/iam?project=tts-datagov)
 - [ ] Remove team member from AWS OPP account
 - [ ] Remove team member from [AWS sandbox access](https://github.com/GSA/datagov-iam/blob/main/README.md#new-users)
-- [ ] Remove team member from [jumpbox operators](https://github.com/GSA/datagov-deploy/blob/develop/ansible/group_vars/all/vars.yml)
+- [ ] Remove team member from [jumpbox operators](https://github.com/GSA/datagov-deploy/blob/master/ansible/group_vars/all/vars.yml)
 - [ ] Remove team member from Data.gov email lists
   - [datagov](https://groups.google.com/a/gsa.gov/forum/#!forum/datagov)
   - [datagovhelp](https://groups.google.com/a/gsa.gov/forum/#!forum/datagovhelp)

--- a/.github/ISSUE_TEMPLATE/onboard-team-member.md
+++ b/.github/ISSUE_TEMPLATE/onboard-team-member.md
@@ -73,11 +73,11 @@ For new Project Management Office team members, follow these additional steps:
 - [ ] [Request access](https://docs.google.com/forms/d/e/1FAIpQLSetStmwqrbMWDz_WIlh1trjhP0PFCjKXHzshsJveYmtIvlG2Q/viewform) to Data.gov systems; select “Catalog Admin” for the system, and “Data.gov team member” for justification
 - [ ] Add yourself for [AWS sandbox access](https://github.com/GSA/datagov-iam/tree/master/README.md#new-users)
 - [ ] Request access to AWS OPP account from team member
-- [ ] Add your public SSH key to [GSA/datagov-deploy](https://github.com/GSA/datagov-deploy/blob/develop/ansible/group_vars/all/vars.yml)
+- [ ] Add your public SSH key to [GSA/datagov-deploy](https://github.com/GSA/datagov-deploy/blob/master/ansible/group_vars/all/vars.yml)
 - [ ] Setup the Ansible vault
   - Clone the [datagov-deploy](https://github.com/GSA/datagov-deploy) repo
     locally
-  - Follow the setup instructions for [development](https://github.com/GSA/datagov-deploy/blob/develop/README.md#development)
+  - Follow the setup instructions for [development](https://github.com/GSA/datagov-deploy/blob/master/README.md#development)
   - Follow the [ansible-vault instructions](https://github.com/GSA/datagov-deploy#editing-vault-secrets)
   - Open a vault file `pipenv run ansible-vault view ansible/inventories/sandbox/group_vars/all/vault.yml`, you should see yaml in clear text.
 - [ ] Connect to the [GSA VPN](https://github.com/GSA/datagov-deploy/wiki/gsa-vpn) for access to the staging and production environments.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -206,7 +206,6 @@ Work that is currently in progress.
 - The deployment must follow our Configuration Management plan. If not possible,
   contact the Program Management team to modify the story or discuss how to
   update the Configuration Management plan.
-- Task has been merged to develop/master and should be applied to the AWS sandbox environments.
 
 #### Blocked
 
@@ -222,26 +221,14 @@ occasional nudging to get it unblocked.
 
 #### Needs Review
 
-Task has one or more items that need peer review before being moved to Ready for Deploy. 
+Task has one or more items that need peer review before being merged.
 
 
 ##### Exit criteria
 
 - Work has been reviewed and approved by one or more members of the data.gov team.
-- If applicable, work is ready to be included on the next release. Usually through integration in the `develop` or `main` branches.
-
-#### Ready for deploy
-
-Task has been merged to develop/master and applied to the sandbox environments
-(AWS via terraform) and ready to be deployed BSP staging and production
-environments.
-
-
-##### Exit criteria
-
-- Work exists on a release branch.
-- Work has been applied to BSP staging.
-- Work has been applied to BSP production.
+- Work is ready to be included on the next release.
+- Work has been merged to `master` or `main` branches.
 
 
 #### Done
@@ -284,45 +271,18 @@ for detailed manual deployment steps.
 
 ### Platform deployment (datagov-deploy)
 
-We use `develop` as the default branch and stage releases with a release branch
-(`release/*`). The BSP environment can be hard to test in, so having a staged
-release allows us to debug and fix BSP issues without slowing down sprint
-development.
-
-For [datagov-deploy][datagov-deploy], we use the [git flow
-pattern](https://danielkummer.github.io/git-flow-cheatsheet/) to coordinate
-delivery of features and bugfixes between branches. Generally, new features will
-arrive in the `develop` branch, then periodically be gathered up and deployed
-into staging via `release/*` branches, then deployed into production via the
-`master` branch.  _Note: we don't use the git-flow program itself since work
-must be merged via pull-requests, which that tool doesn't support._
+We use `master` as the default branch. Any changes are automatically deployed to
+the FCS environments after merge by
+[CI](https://ci-datagov.mgmt-ocsit.bsp.gsa.gov/). The `develop` branch is
+available ad-hoc in order to test changes within the AWS sandbox.
 
 Branch | Deployed to | Frequency
 ------ | ----------- | ---------
-`develop` | AWS sandboxes | manual
-`release/*` | BSP dev (staging) | manual
-`master` | BSP prod | manual
+`develop` | AWS sandboxes | On push
+`master` | FCS environments | On push
 
 See [Releases](https://github.com/GSA/datagov-deploy/wiki/Releases) for details
 on the platform deployment steps.
-
-#### Hotfixes
-
-Occasionally for the platform, we need to skip the usual development workflow to
-address an urgent issue. This is because `develop` requires a lot of manual
-testing and might not always be in a deployable state (even though we try).
-`hotfix/*` branches are created from the `master` branch and allow us to do the
-manual testing and validation on a small set of isolated changes.
-
-Use your discretion when creating a hotfix. These are some reasons to create
-a hotfix:
-- Resolve a significant site outage
-- Fix a major bug
-- Change to the Ansible inventory (new/removed hosts)
-- Removing operator access
-
-Once the hotfix PR is merged, you should create a backmerge PR into develop (merge
-the `hotfix/*` branch into `develop).
 
 
 ## Pull requests
@@ -341,9 +301,9 @@ What should you do when you review a PR?
   - Code is in a deployable state
 
 Any critical CI checks should be enforced by GitHub on protected branches
-(`develop` and `master`), so it's not required that CI checks are passing in
-order to approve a PR. Instead, it's important that tests have been added and
-they are running in CI.
+(`master`), so it's not required that CI checks are passing in order to approve
+a PR. Instead, it's important that tests have been added and they are running in
+CI.
 
 Data.gov encompasses many technologies (too many, in fact) and it's not
 practical to have everyone be an expert at everything nor to have only a single

--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ GSA [VPN access](https://github.com/GSA/datagov-deploy/wiki/GSA-VPN) is required
 
 Environment | Deployment branch                      | ISP         | Jumpbox
 ----------- | -----------------                      | ---         | ----
-mgmt        | `master` (semi-manual)                 | BSP         | datagovjump1m.mgmt-ocsit.bsp.gsa.gov
-production  | `master` (semi-manual)                 | BSP         | datagov-jump2p.prod-ocsit.bsp.gsa.gov
-staging     | `release/*` and `master` (semi-manual) | BSP         | datagov-jump2d.dev-ocsit.bsp.gsa.gov
-sandbox     | `develop`                              | AWS sandbox | jump.sandbox.datagov.us
-local       | feature branches                       | laptop      | localhost
+mgmt        | `master`         | BSP         | datagovjump1m.mgmt-ocsit.bsp.gsa.gov
+production  | `master`         | BSP         | datagov-jump2p.prod-ocsit.bsp.gsa.gov
+staging     | `master`         | BSP         | datagov-jump2d.dev-ocsit.bsp.gsa.gov
+sandbox     | `develop`        | AWS sandbox | jump.sandbox.datagov.us
+local       | feature branches | laptop      | localhost
 
 
 ## Usage
@@ -134,7 +134,7 @@ Install the common Services.
 Upgrade OS packages as a one-off command on all hosts. _Note: If you find you're
 doing one-off ansible commands often, then you should consider creating
 a [situational
-playbook](https://github.com/GSA/datagov-deploy/tree/develop/ansible/actions)._
+playbook](https://github.com/GSA/datagov-deploy/tree/master/ansible/actions)._
 
     $ ansible -m apt -a 'update_cache=yes upgrade=dist' all
 
@@ -534,7 +534,7 @@ off deployment to Jenkins.
 
 Workflow   | Environments              | URL
 --------   | ------------              | ---
-production | staging, mgmt, production | https://ci.data.gov
+production | staging, mgmt, production | https://ci-datagov.mgmt-ocsit.bsp.gsa.gov
 sandbox    | sandbox                   | https://ci.sandbox.datagov.us
 
 
@@ -549,24 +549,20 @@ to be done.
 
 1. Log into the new instance
 1. Configure credentials
-1. Add a CI bot user and API token
-
-
-#### Log into Jenkins
-
-[Log into](https://ci.sandbox.datagov.us/) the Jenkins instance using
-`jenkins_admin_username` (default: admin) and `jenkins_admin_password` (see
-vault).
+1. Add an API token for the admin user and update `jenkins_admin_password` with
+   this token.
+1. (sandbox only) Add a CI bot user and API token
 
 
 #### Configure credentials
 
-Add [credentials](https://ci.sandbox.datagov.us/credentials/) to manage secrets.
+Add [credentials](https://ci-datagov.mgmt-ocsit.bsp.gsa.gov/credentials/) to manage secrets.
 
 | Id                   | Type | Description |
 | --                   | ---- | ----------- |
 | ansible-vault-secret | file | File containing the password to the Ansible vault (ansible-secret-v2.txt). |
 | datagov-sandbox      | file | [Root SSH private key](https://drive.google.com/drive/folders/10-hk-IqA0jQAW6727pKmW46EF-nHiNLr) file for the environment. |
+| datagov-prod-ssh     | file | [Root SSH private key](https://drive.google.com/drive/folders/10-hk-IqA0jQAW6727pKmW46EF-nHiNLr) file for the environment. |
 | github-datagov-bot   | text | Personal [access token](https://github.com/settings/tokens) from the datagov-bot GitHub user. |
 
 _Note: evaluate if we want to move the credential creation to
@@ -577,7 +573,7 @@ configuration-as-code configuraiton._
 
 With SAML authentication enabled, you can no longer create user/service accounts
 through the UI. Instead, use the [script
-console](https://ci.sandbox.datagov.us/script) to run the script below. Set
+console](https://ci-datagov.mgmt-ocsit.bsp.gsa.gov/script) to run the script below. Set
 a random password. The return value is the API token. Save this for later as you won't have
 another chance.
 


### PR DESCRIPTION
This updates documentation to drop `develop` as the default branch. All features
and bugfixes will be based on `master`. Hotfixes are no longer necessary, and it
will no longer be necessary to deploy to sandbox first.

`develop` branch becomes an ad-hoc un-protected branch that folks can use for
deploying to the sandbox for any development and testing.