### PR TITLE
Report deploy issues to datagov-deploy

### DIFF
--- a/ansible/inventories/mgmt/group_vars/all/vars.yml
+++ b/ansible/inventories/mgmt/group_vars/all/vars.yml
@@ -111,7 +111,6 @@ jenkins_jobs:
     git_ref: fcs
   - name: deploy-ci-app-catalog-next
     git_url: https://github.com/gsa/catalog.data.gov.git
-    github_project_url: https://github.com/gsa/datagov-ckan-multi
     git_ref: fcs
   - name: deploy-ci-app-dashboard
     git_url: https://github.com/gsa/project-open-data-dashboard.git

--- a/ansible/inventories/sandbox/group_vars/all/vars.yml
+++ b/ansible/inventories/sandbox/group_vars/all/vars.yml
@@ -141,7 +141,6 @@ jenkins_jobs:
     git_url: https://github.com/gsa/catalog-app.git
   - name: deploy-ci-app-catalog-next
     git_url: https://github.com/gsa/catalog.data.gov.git
-    github_project_url: https://github.com/gsa/datagov-ckan-multi
   - name: deploy-ci-app-dashboard
     git_url: https://github.com/gsa/project-open-data-dashboard.git
   - name: deploy-ci-app-inventory


### PR DESCRIPTION
With the ckan-multi work handed off, any issues from a failed deployment should
be opened in the default datagov-deploy repo.