### PR TITLE
[common] work-around sysctl error for ipv6

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -49,7 +49,7 @@
   version: v1.3.2
 - name: gsa.datagov-deploy-common
   src: https://github.com/GSA/datagov-deploy-common
-  version: v4.3.0
+  version: v4.3.1
 - name: gsa.datagov-deploy-fgdc2iso
   src: https://github.com/GSA/datagov-deploy-fgdc2iso
   version: v1.0.4


### PR DESCRIPTION
https://github.com/GSA/datagov-deploy/issues/2655

The hardening playbook disables ipv6, but then attempts to configure it which
results in an error when sysctl reloads for an unrelated change. Instead, we
leave the ipv6 subsystem enabled, but disable it via sysctl.

This also cleans up the GRUB_CMDLINE_LINUX setting. The hardening playbook
creates multiple lines of this, which is not allowed. GRUB will only read the
last one which means some security settings have not been enabled correctly.
Work-around this by updating the last GRUB_CMDLINE_LINUX line with all the
options we expect.