### PR TITLE
[catalog] run host-level smoke tests from host

### DIFF
--- a/ansible/catalog-web.yml
+++ b/ansible/catalog-web.yml
@@ -98,7 +98,6 @@
             fail_msg: |
               POST redirect failed (we expect 307 redirection to the writable instance)
               {{ response.content }}
-      delegate_to: localhost
       become: false
       run_once: true
       tags:
@@ -128,7 +127,6 @@
             fail_msg: |
               POST redirect failed (we expect redirection to the writable instance)
               {{ response.content }}
-      delegate_to: localhost
       become: false
       run_once: true
       tags:


### PR DESCRIPTION
Firewalls prevent requests to web instances. Make sure any host-level smoke
tests are run directly on the host.

Only service-level checks should use delegate_to.