### PR TITLE
[pycsw] remove catalog-classic from pycsw

### DIFF
--- a/ansible/inventories/production/hosts
+++ b/ansible/inventories/production/hosts
@@ -91,9 +91,6 @@ pycsw-web-v1
 pycsw-web-v2
 
 [pycsw-web-v1:children]
-# We install pycsw on all catalog-web hosts
-catalog-web-v1
-
 [pycsw-web-v2:children]
 # We install pycsw on readonly catalog-web hosts
 catalog-next-web-a
@@ -104,7 +101,6 @@ pycsw-worker-v1
 pycsw-worker-v2
 
 [pycsw-worker-v1]
-
 [pycsw-worker-v2]
 # We configure only a single worker for pycsw, usually the misc worker.
 catalogharvester2p.prod-ocsit.bsp.gsa.gov

--- a/ansible/inventories/sandbox/hosts
+++ b/ansible/inventories/sandbox/hosts
@@ -5,14 +5,10 @@
 # [1]: https://github.com/GSA/datagov-infrastructure-live
 
 [catalog-fgdc2iso]
-catalog-fgdc2iso1tf.internal.sandbox.datagov.us
 catalog-next-fgdc2iso1tf.internal.sandbox.datagov.us
 
 [catalog-harvester]
-catalog-harvester1tf.internal.sandbox.datagov.us
-
 [catalog-web]
-catalog-web1tf.internal.sandbox.datagov.us
 
 [catalog-next:children]
 catalog-next-web
@@ -47,10 +43,7 @@ pycsw-web
 pycsw-worker
 
 [pycsw-web-v1]
-catalog-web1tf.internal.sandbox.datagov.us
-
 [pycsw-worker-v1]
-catalog-harvester1tf.internal.sandbox.datagov.us
 
 [pycsw-web-v2]
 catalog-next-web1tf.internal.sandbox.datagov.us
@@ -69,12 +62,25 @@ pycsw-worker-v2
 [wordpress-web]
 wordpress-web1tf.internal.sandbox.datagov.us
 
+[v1]
+# TODO when admin-catalog is removed, we can remove catalog-classic in
+# datagov-infrastructure-live, but until then, we still want to keep these
+# hosts in the inventory to receive OS updates.
+catalog-harvester1tf.internal.sandbox.datagov.us
+catalog-web1tf.internal.sandbox.datagov.us
+
 [v1:children]
 catalog-harvester
 catalog-web
 inventory-web
 pycsw-web-v1
 pycsw-worker-v1
+
+[v2]
+# TODO when admin-catalog is removed, we can remove catalog-classic in
+# datagov-infrastructure-live, but until then, we still want to keep these
+# hosts in the inventory to receive OS updates.
+catalog-fgdc2iso1tf.internal.sandbox.datagov.us
 
 [v2:children]
 catalog-fgdc2iso

--- a/ansible/inventories/staging/hosts
+++ b/ansible/inventories/staging/hosts
@@ -90,9 +90,6 @@ datagov-jump2d.dev-ocsit.bsp.gsa.gov
 pycsw-web-v1
 
 [pycsw-web-v1:children]
-# We install pycsw on all catalog-web hosts
-catalog-web-v1
-
 [pycsw-worker:children]
 pycsw-worker-v1
 


### PR DESCRIPTION
We've already removed most of catalog-classic but admin-catalog is still live.
Make sure to remove it from the pycsw group so it no longer deployed with
pycsw.