### PR TITLE
inventory v1 datagov_in_service false

### DIFF
--- a/ansible/inventories/production/group_vars/inventory-web-v1/vars.yml
+++ b/ansible/inventories/production/group_vars/inventory-web-v1/vars.yml
@@ -1,2 +1,2 @@
 ---
-datagov_in_service: true
+datagov_in_service: false


### PR DESCRIPTION
Temporarily put inventory-bsp instances out of service during switchover, so playbook won't restart apache2 on the v1 instances when we want them down.