### PR TITLE
use inventory.data.gov for inventory-next

### DIFF
--- a/ansible/inventories/production/group_vars/all/vars.yml
+++ b/ansible/inventories/production/group_vars/all/vars.yml
@@ -213,7 +213,7 @@ inventory_next_ckan_s3_bucket_name: "{{ vault_inventory_next_ckan_s3_bucket_name
 inventory_next_ckan_s3_bucket_prefix: "{{ vault_inventory_next_ckan_s3_bucket_prefix }}"
 inventory_next_ckan_instance_secret: "{{ vault_inventory_next_ckan_instance_secret }}"
 inventory_next_ckan_instance_uuid: "{{ vault_inventory_next_ckan_instance_uuid }}"
-inventory_next_ckan_service_url: https://inventory-next.data.gov
+inventory_next_ckan_service_url: https://inventory.data.gov
 inventory_next_ckan_solr_host: datagov-solrm1p-v2.prod-ocsit.bsp.gsa.gov
 inventory_next_ckan_who_ini_secret: "{{ vault_inventory_next_ckan_who_ini_secret }}"
 inventory_next_datastore_login_host: "{{ vault_inventory_next_datastore_login_host }}"

--- a/ansible/inventories/production/group_vars/inventory-next/vars.yml
+++ b/ansible/inventories/production/group_vars/inventory-next/vars.yml
@@ -47,7 +47,7 @@ inventory_ckan_saml2_requested_authn_context:
 
 # login.gov identity sandbox
 saml2_idp_metadata_url: "https://idp.int.identitysandbox.gov/api/saml/metadata2020"
-saml2_site_url: "https://inventory-next.data.gov/"
+saml2_site_url: "https://inventory.data.gov/"
 
 saml2_sp_public_certificate: "{{ vault_inventory_next_saml2_sp_public_certificate }}"
 saml2_sp_private_key: "{{ vault_inventory_next_saml2_sp_private_key }}"


### PR DESCRIPTION
Use production url `inventory.data.gov` when inventory-next goes live after switchover.
Config change on login.gov Data.gov Inventory app need to go together with this.