### PR TITLE
Remove release task from O&M

### DIFF
--- a/.github/ISSUE_TEMPLATE/o-and-m.md
+++ b/.github/ISSUE_TEMPLATE/o-and-m.md
@@ -24,4 +24,3 @@ You are responsible for all [O&M responsibilities](https://github.com/GSA/datago
 - [ ] Weekly [Snyk scan](https://github.com/GSA/datagov-deploy/wiki/Operation-and-Maintenance-Responsibilities#automated-dependency-updates-ad-hoc-github-prs) is complete.
 - [ ] If received, the monthly [Netsparker scan](https://github.com/GSA/datagov-deploy/wiki/Operation-and-Maintenance-Responsibilities#netsparker-compliance-scan-report-from-isso) has been triaged.
 - [ ] Finishing the shift: Log the [number of alerts](https://docs.google.com/spreadsheets/d/1u1hSUAQW6FWzphog122stfB6MB9Wiq0NROT3PeicRoM/edit#gid=939071144) 
-- [ ] Finishing the shift: Release the [static sites](https://github.com/GSA/datagov-deploy/wiki/Releases#release-static-sites)


### PR DESCRIPTION
No more releases necessary since work is merged to production after review.