### PR TITLE
[inventory] remove inventory-classic instances

### DIFF
--- a/ansible/inventories/mgmt/group_vars/all/vars.yml
+++ b/ansible/inventories/mgmt/group_vars/all/vars.yml
@@ -119,9 +119,6 @@ jenkins_jobs:
   - name: deploy-ci-app-inventory
     git_url: https://github.com/gsa/inventory-app.git
     git_ref: fcs
-  - name: deploy-ci-app-inventory-next
-    git_url: https://github.com/gsa/inventory-app.git
-    git_ref: inventory_ckan_2.8
   - name: deploy-ci-app-wordpress
     git_url: https://github.com/gsa/datagov-wp-boilerplate.git
     git_ref: fcs

--- a/ansible/inventories/production/group_vars/inventory-next/vars.yml
+++ b/ansible/inventories/production/group_vars/inventory-next/vars.yml
@@ -31,7 +31,7 @@ inventory_ckan_bucket_name: "{{ inventory_next_ckan_s3_bucket_name }}"
 inventory_ckan_bucket_prefix: "{{ inventory_next_ckan_s3_bucket_prefix }}"
 ckan_site_domain: "{{ inventory_next_ckan_service_url }}"
 
-inventory_app_repo_branch: inventory_ckan_2.8
+inventory_app_repo_branch: fcs
 newrelic_app_name: inventory-next
 newrelic_enabled: true
 

--- a/ansible/inventories/production/group_vars/v2/vars.yml
+++ b/ansible/inventories/production/group_vars/v2/vars.yml
@@ -3,6 +3,6 @@ catalog_ckan_app_version: bionic
 
 common_python_version_number: 2.7.16
 
-inventory_app_repo_branch: inventory_ckan_2.8
+inventory_app_repo_branch: fcs
 
 trendmicro_deb_url: https://dsm.sec.helix.gsa.gov/software/agent/Ubuntu_18.04/x86_64/

--- a/ansible/inventories/production/host_vars/inventory1p.prod-ocsit.bsp.gsa.gov/vars.yml
+++ b/ansible/inventories/production/host_vars/inventory1p.prod-ocsit.bsp.gsa.gov/vars.yml
@@ -1,3 +1,0 @@
----
-# Enable crons only on specific hosts
-crons_enabled: true

--- a/ansible/inventories/production/hosts
+++ b/ansible/inventories/production/hosts
@@ -70,7 +70,6 @@ dashboardweb[1:2]p.prod-ocsit.bsp.gsa.gov
 inventory-web-v1
 
 [inventory-web-v1]
-inventory[1:2]p.prod-ocsit.bsp.gsa.gov
 
 [inventory-next]
 inventory-[1:2]p.prod-ocsit.bsp.gsa.gov

--- a/ansible/inventories/sandbox/group_vars/all/vars.yml
+++ b/ansible/inventories/sandbox/group_vars/all/vars.yml
@@ -148,9 +148,6 @@ jenkins_jobs:
   - name: deploy-ci-app-inventory
     git_url: https://github.com/gsa/inventory-app.git
     git_ref: fcs
-  - name: deploy-ci-app-inventory-next
-    git_url: https://github.com/gsa/inventory-app.git
-    git_ref: inventory_ckan_2.8
   - name: deploy-ci-app-wordpress
     git_url: https://github.com/gsa/datagov-wp-boilerplate.git
     git_ref: fcs

--- a/ansible/inventories/sandbox/hosts
+++ b/ansible/inventories/sandbox/hosts
@@ -33,7 +33,6 @@ datagov-solr1tf.internal.sandbox.datagov.us
 inventory-next-web1tf.internal.sandbox.datagov.us
 
 [inventory-web]
-inventory-web1tf.internal.sandbox.datagov.us
 
 [jenkins]
 jenkins1tf.internal.sandbox.datagov.us

--- a/ansible/inventories/staging/group_vars/inventory-next/vars.yml
+++ b/ansible/inventories/staging/group_vars/inventory-next/vars.yml
@@ -31,7 +31,7 @@ inventory_ckan_bucket_name: "{{ inventory_next_ckan_s3_bucket_name }}"
 inventory_ckan_bucket_prefix: "{{ inventory_next_ckan_s3_bucket_prefix }}"
 ckan_site_domain: "{{ inventory_next_ckan_service_url }}"
 
-inventory_app_repo_branch: inventory_ckan_2.8
+inventory_app_repo_branch: fcs
 newrelic_app_name: inventory-next
 
 inventory_ckan_plugins_additional: [saml2auth s3filestore]

--- a/ansible/inventories/staging/group_vars/v2/vars.yml
+++ b/ansible/inventories/staging/group_vars/v2/vars.yml
@@ -3,6 +3,6 @@ catalog_ckan_app_version: bionic
 
 common_python_version_number: 2.7.16
 
-inventory_app_repo_branch: inventory_ckan_2.8
+inventory_app_repo_branch: fcs
 
 trendmicro_deb_url: https://dsm.sec.helix.gsa.gov/software/agent/Ubuntu_18.04/x86_64/

--- a/ansible/inventories/staging/host_vars/inventory-next-1d.dev-ocsit.bsp.gsa.gov/vars.yml
+++ b/ansible/inventories/staging/host_vars/inventory-next-1d.dev-ocsit.bsp.gsa.gov/vars.yml
@@ -1,3 +1,0 @@
----
-# Enable crons only on specific hosts
-crons_enabled: true

--- a/ansible/inventories/staging/host_vars/inventory1d.dev-ocsit.bsp.gsa.gov/vars.yml
+++ b/ansible/inventories/staging/host_vars/inventory1d.dev-ocsit.bsp.gsa.gov/vars.yml
@@ -1,3 +1,0 @@
----
-# Enable crons only on specific hosts
-crons_enabled: true

--- a/ansible/inventories/staging/hosts
+++ b/ansible/inventories/staging/hosts
@@ -70,7 +70,6 @@ dashboardweb[1:2]d.dev-ocsit.bsp.gsa.gov
 inventory-web-v1
 
 [inventory-web-v1]
-inventory[1:2]d.dev-ocsit.bsp.gsa.gov
 
 [inventory-next]
 inventory-[1:2]d.dev-ocsit.bsp.gsa.gov

--- a/ansible/roles/software/ckan/inventory/molecule/default/molecule.yml
+++ b/ansible/roles/software/ckan/inventory/molecule/default/molecule.yml
@@ -35,7 +35,7 @@ provisioner:
         inventory_ckan_envs: |
           TEST_ENV=1
       bionic:
-        inventory_app_repo_branch: inventory_ckan_2.8
+        inventory_app_repo_branch: fcs
         inventory_next: true
         datapusher_build_pkg_branch: datagov/inventory-next
 scenario:

--- a/ansible/roles/software/ckan/inventory/molecule/default/molecule.yml
+++ b/ansible/roles/software/ckan/inventory/molecule/default/molecule.yml
@@ -6,10 +6,6 @@ dependency:
 driver:
   name: docker
 platforms:
-  - name: ckan-inventory-app-trusty
-    image: ubuntu:trusty
-    groups:
-      - trusty
   - name: ckan-inventory-app-bionic
     image: ubuntu:bionic
     groups:

--- a/ansible/roles/software/ckan/inventory/molecule/in_service/molecule.yml
+++ b/ansible/roles/software/ckan/inventory/molecule/in_service/molecule.yml
@@ -6,10 +6,6 @@ dependency:
 driver:
   name: docker
 platforms:
-  - name: inventory-ckan-trusty
-    image: ubuntu:trusty
-    groups:
-      - trusty
   - name: inventory-ckan-bionic
     image: ubuntu:bionic
     groups:

--- a/ansible/roles/software/ckan/inventory/molecule/in_service/molecule.yml
+++ b/ansible/roles/software/ckan/inventory/molecule/in_service/molecule.yml
@@ -34,7 +34,7 @@ provisioner:
         inventory_ckan_solr_port: 8983
         db_is_setup: false
       bionic:
-        inventory_app_repo_branch: inventory_ckan_2.8
+        inventory_app_repo_branch: fcs
         datapusher_build_pkg_branch: datagov/inventory-next
         inventory_next: true
 scenario:

--- a/ansible/roles/software/ckan/inventory/molecule/inventory-next/molecule.yml
+++ b/ansible/roles/software/ckan/inventory/molecule/inventory-next/molecule.yml
@@ -28,7 +28,7 @@ provisioner:
         db_is_setup: false
         python_home: /usr
         inventory_ckan_solr_port: 8983
-        inventory_app_repo_branch: inventory_ckan_2.8
+        inventory_app_repo_branch: fcs
         inventory_next: true
         datapusher_build_pkg_branch: datagov/inventory-next
         inventory_ckan_saml2_entity_id: urn:gov:gsa:SAML:2.0.profiles:sp:sso:gsa:datagov-sandbox-inventory


### PR DESCRIPTION
https://github.com/GSA/datagov-deploy/issues/2941

Updates branch references for inventory-next. The inventory-classic branch has been removed, inventory_ckan_2.8 renamed to `fcs`.