### PR TITLE
Use HSTS header only for internal traffic

### DIFF
--- a/ansible/roles/software/ckan/catalog/ckan-app/templates/etc_apache2_sites-enabled_ckan.conf.j2
+++ b/ansible/roles/software/ckan/catalog/ckan-app/templates/etc_apache2_sites-enabled_ckan.conf.j2
@@ -67,8 +67,9 @@
 
     Header set Referrer-Policy "origin"
 
-    Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains"
-
+    <If "%{HTTP_HOST} in { '{{ ansible_fqdn }}', '{{ ansible_default_ipv4.address | default('') }}' } ">
+      Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains"
+    </If>
     # Header set Content-Security-Policy "default-src 'self'"
 
     RewriteEngine On

--- a/ansible/roles/software/ckan/inventory/templates/etc/apache2/sites-enabled/ckan.conf
+++ b/ansible/roles/software/ckan/inventory/templates/etc/apache2/sites-enabled/ckan.conf
@@ -35,7 +35,9 @@ WSGISocketPrefix /var/run/wsgi
 
     Header add Referrer-Policy "origin"
 
-    Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains"
+    <If "%{HTTP_HOST} in { '{{ ansible_fqdn }}', '{{ ansible_default_ipv4.address | default('') }}' } ">
+      Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains"
+    </If>
 
     # Header add Content-Security-Policy "default-src 'self'"
 


### PR DESCRIPTION
For https://github.com/GSA/datagov-deploy/issues/2598.
Add HSTS header only for traffic targeted to internal hosts. This avoids duplicated HSTS entries in external traffic.