### PR TITLE
[solr] remove solr-classic replicas

### DIFF
--- a/ansible/inventories/production/hosts
+++ b/ansible/inventories/production/hosts
@@ -115,7 +115,6 @@ redis1p.prod-ocsit.bsp.gsa.gov
 
 [solr]
 datagov-solrm1p.prod-ocsit.bsp.gsa.gov
-datagov-solr[1:2]p.prod-ocsit.bsp.gsa.gov is_solr_replica=true
 
 [solr-next]
 datagov-solrm1p-v2.prod-ocsit.bsp.gsa.gov

--- a/ansible/inventories/staging/hosts
+++ b/ansible/inventories/staging/hosts
@@ -105,7 +105,6 @@ redis1d.dev-ocsit.bsp.gsa.gov
 
 [solr]
 datagov-solrm1d.dev-ocsit.bsp.gsa.gov
-datagov-solr[1:2]d.dev-ocsit.bsp.gsa.gov is_solr_replica=true
 
 [solr-next]
 datagov-solrm1d-v2.dev-ocsit.bsp.gsa.gov


### PR DESCRIPTION
https://github.com/GSA/datagov-deploy/issues/2941

We still have catalog-admin which requires the solr-classic primary. The
replicas can be removed.