### PR TITLE
Use HSTS header only for internal traffic

### DIFF
--- a/ansible/roles/software/ckan/catalog/ckan-app/templates/etc_apache2_sites-enabled_ckan.conf.j2
+++ b/ansible/roles/software/ckan/catalog/ckan-app/templates/etc_apache2_sites-enabled_ckan.conf.j2
@@ -67,8 +67,10 @@
 
     Header set Referrer-Policy "origin"
 
-    Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains"
-
+    # Avoid duplicate HSTS. Netscaler adds it for external data.gov traffic  
+    <If "! %{HTTP_HOST} =~  /\.data\.gov$/">
+      Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains"
+    </If>
     # Header set Content-Security-Policy "default-src 'self'"
 
     RewriteEngine On

--- a/ansible/roles/software/ckan/inventory/templates/etc/apache2/sites-enabled/ckan.conf
+++ b/ansible/roles/software/ckan/inventory/templates/etc/apache2/sites-enabled/ckan.conf
@@ -35,7 +35,10 @@ WSGISocketPrefix /var/run/wsgi
 
     Header add Referrer-Policy "origin"
 
-    Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains"
+    # Avoid duplicate HSTS. Netscaler adds it for external data.gov traffic  
+    <If "! %{HTTP_HOST} =~  /\.data\.gov$/">
+      Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains"
+    </If>
 
     # Header add Content-Security-Policy "default-src 'self'"
 


### PR DESCRIPTION
For #2598.
Avoid duplicate HSTS. Netscaler already adds it for external data.gov traffic.