### PR TITLE
Internal hsts header

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -43,7 +43,7 @@
   version: 1.0.4
 - name: gsa.datagov-deploy-dashboard
   src: https://github.com/GSA/datagov-deploy-dashboard
-  version: v1.1.7
+  version: v1.1.8
 - name: gsa.datagov-deploy-apache2
   src: https://github.com/GSA/datagov-deploy-apache2
   version: v1.3.2

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -43,7 +43,7 @@
   version: 1.0.4
 - name: gsa.datagov-deploy-dashboard
   src: https://github.com/GSA/datagov-deploy-dashboard
-  version: v1.1.6
+  version: v1.1.7
 - name: gsa.datagov-deploy-apache2
   src: https://github.com/GSA/datagov-deploy-apache2
   version: v1.3.2
@@ -70,7 +70,7 @@
   version: v1.2.1
 - name: gsa.datagov-deploy-wordpress
   src: https://github.com/GSA/datagov-deploy-wordpress.git
-  version: v1.0.10
+  version: v1.0.11
 - name: jnv.unattended-upgrades
   version: v1.8.0
 - name: jobscore.beats

--- a/ansible/roles/software/ckan/catalog/ckan-app/templates/etc_apache2_sites-enabled_ckan.conf.j2
+++ b/ansible/roles/software/ckan/catalog/ckan-app/templates/etc_apache2_sites-enabled_ckan.conf.j2
@@ -67,10 +67,11 @@
 
     Header set Referrer-Policy "origin"
 
-    # Avoid duplicate HSTS. Netscaler adds it for external data.gov traffic  
-    <If "! %{HTTP_HOST} =~  /\.data\.gov$/">
+    # Avoid duplicate HSTS. Netscaler adds it for external traffic
+    <If "%{HTTP_HOST} in { '{{ ansible_fqdn }}', '{{ ansible_default_ipv4.address | default('') }}' } ">
       Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains"
     </If>
+
     # Header set Content-Security-Policy "default-src 'self'"
 
     RewriteEngine On

--- a/ansible/roles/software/ckan/inventory/templates/etc/apache2/sites-enabled/ckan.conf
+++ b/ansible/roles/software/ckan/inventory/templates/etc/apache2/sites-enabled/ckan.conf
@@ -35,8 +35,8 @@ WSGISocketPrefix /var/run/wsgi
 
     Header add Referrer-Policy "origin"
 
-    # Avoid duplicate HSTS. Netscaler adds it for external data.gov traffic  
-    <If "! %{HTTP_HOST} =~  /\.data\.gov$/">
+    # Avoid duplicate HSTS. Netscaler adds it for external traffic
+    <If "%{HTTP_HOST} in { '{{ ansible_fqdn }}', '{{ ansible_default_ipv4.address | default('') }}' } ">
       Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains"
     </If>
 


### PR DESCRIPTION
For https://github.com/GSA/datagov-deploy/issues/2598

Previous fix not ideal. It ignores staging situation where `*.bsp.gsa.gov `is used for external URL, not `*.data.gov`. Redo the logic, using hostname/ip address to tell it is internal traffic or not.

Waiting for new tags ready on dashboard and wordpress repos.