### PR TITLE
Bump retries for wordpress

### DIFF
--- a/ansible/datagov-web.yml
+++ b/ansible/datagov-web.yml
@@ -36,7 +36,7 @@
         # https://github.com/GSA/datagov-deploy/issues/900
         validate_certs: false
       register: result
-      retries: 3
+      retries: 5
       delay: 10
       until: not result.failed
 
@@ -101,6 +101,6 @@
       delegate_to: localhost
       become: false
       register: result
-      retries: 3
+      retries: 5
       delay: 10
       until: not result.failed


### PR DESCRIPTION
Have seen multiple failures of wordpress not being up properly, but application will be working as expected.
Related to #3048 .