### PR TITLE
Remove solr classic hosts (primary)

### DIFF
--- a/ansible/inventories/production/hosts
+++ b/ansible/inventories/production/hosts
@@ -78,7 +78,6 @@ redis-next
 redis1p.prod-ocsit.bsp.gsa.gov
 
 [solr]
-datagov-solrm1p.prod-ocsit.bsp.gsa.gov
 
 [solr-next]
 datagov-solrm1p-v2.prod-ocsit.bsp.gsa.gov

--- a/ansible/inventories/staging/hosts
+++ b/ansible/inventories/staging/hosts
@@ -62,7 +62,6 @@ redis-next
 redis1d.dev-ocsit.bsp.gsa.gov
 
 [solr]
-datagov-solrm1d.dev-ocsit.bsp.gsa.gov
 
 [solr-next]
 datagov-solrm1d-v2.dev-ocsit.bsp.gsa.gov


### PR DESCRIPTION
https://github.com/GSA/datagov-deploy/issues/2838

inventory and catalog classic instances have been removed. It's now safe to
remove the remaining solr classic instances. The solr classic replicas have
already been removed.
