### PR TITLE
Upgrade tomcat version

### DIFF
--- a/ansible/fgdc2iso.yml
+++ b/ansible/fgdc2iso.yml
@@ -7,7 +7,7 @@
     - role: robertdebock.java
     - role: robertdebock.tomcat
       vars:
-        tomcat_version9: "9.0.46"
+        tomcat_version9: "9.0.48"
         tomcat_instances:
           - name: "tomcat"
             version: 9


### PR DESCRIPTION
For compliance
After merging, still need to manually remove current installation to force a new one:

$ ansible -m file -a 'state=absent path=/opt/tomcat' catalog-fgdc2iso
$ ansible-playbook fgdc2iso.yml
