### PR TITLE
refactor to use nginxinc.nginx to get latest nginx version

### DIFF
--- a/ansible/dashboard-web.yml
+++ b/ansible/dashboard-web.yml
@@ -6,7 +6,7 @@
     - { role: software/common/tls, tags: [provision, tls] }
     - { role: software/common/php-common, tags: [provision] }
     - { role: geerlingguy.git, tags: [provision] }
-    - role: geerlingguy.nginx
+    - role: nginxinc.nginx
       tags:
         - nginx
         - provision

--- a/ansible/datagov-web.yml
+++ b/ansible/datagov-web.yml
@@ -6,7 +6,7 @@
     - { role: software/common/tls, tags: [provision, tls] }
     - { role: software/common/php-common, tags: [provision] }
     - { role: geerlingguy.git, tags: [git, provision] }
-    - role: geerlingguy.nginx
+    - role: nginxinc.nginx
       tags:
         - nginx
         - provision

--- a/ansible/fgdc2iso.yml
+++ b/ansible/fgdc2iso.yml
@@ -16,31 +16,58 @@
 - name: Deploy nginx
   hosts: catalog-fgdc2iso
   roles:
-    - role: geerlingguy.nginx
+    - role: nginxinc.nginx
+      tags: [nginx, provision]
+
+- name: Config nginx
+  hosts: catalog-fgdc2iso
+  roles:
+    - role: nginxinc.nginx_config
       vars:
-        nginx_upstreams:
-          - name: "tomcat"
+        nginx_config_http_template_enable: true
+        nginx_config_http_template:
+          app:
+            template_file: http/default.conf.j2
+            conf_file_name: fgdc2iso.conf
+            conf_file_location: /etc/nginx/conf.d/
+            upstreams:
+              tomcat_upstream:
+                name: tomcat
+                servers:
+                  tomcat_server:
+                    address: 127.0.0.1
+                    port: 8080
             servers:
-              - "127.0.0.1:8080"
-        nginx_vhosts:
-          - listen: "80"
-            server_name: "fgdc2iso"
-            filename: "fgdc2iso.80.conf"
-            extra_parameters: |
-              location / {
-                proxy_pass http://tomcat;
-              }
-          - listen: "443 ssl"
-            server_name: "fgdc2iso"
-            filename: "fgdc2iso.443.conf"
-            extra_parameters: |
-              location / {
-                proxy_pass http://tomcat;
-              }
-              ssl_certificate     {{ fgdc2iso_tls_certificate_filepath | default(default_tls_host_certificate_filepath) }};
-              ssl_certificate_key {{ fgdc2iso_tls_key_filepath | default(default_tls_host_key_filepath) }};
-              ssl_protocols       TLSv1.2 TLSv1.3;
-              ssl_ciphers         HIGH:!aNULL:!MD5;
+              http_server:
+                listen:
+                  listen_localhost:
+                    ip: 0.0.0.0
+                    port: 80
+                server_name: fgdc2iso
+                reverse_proxy:
+                  locations:
+                    location1:
+                      location: /
+                      proxy_pass: http://tomcat
+
+              https_server:
+                listen:
+                  listen_localhost:
+                    ip: 0.0.0.0
+                    port: 443
+                    ssl: true
+                server_name: fgdc2iso
+                reverse_proxy:
+                  locations:
+                    location1:
+                      location: /
+                      proxy_pass: http://tomcat
+                ssl:
+                  cert: "{{ fgdc2iso_tls_certificate_filepath | default(default_tls_host_certificate_filepath) }}"
+                  key: "{{ fgdc2iso_tls_key_filepath | default(default_tls_host_key_filepath) }}"
+                  ciphers: "HIGH:!aNULL:!MD5"
+                  protocols: "TLSv1.2 TLSv1.3"
+
       tags: [nginx, provision]
 
 - name: Deploy fgdc2iso

--- a/ansible/jenkins.yml
+++ b/ansible/jenkins.yml
@@ -2,7 +2,7 @@
 - name: Install jenkins
   hosts: jenkins
   roles:
-    - role: geerlingguy.nginx
+    - role: nginxinc.nginx
       tags:
         - nginx
     - role: gsa.datagov-deploy-jenkins

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -21,8 +21,6 @@
   version: 1.9.6
 - name: geerlingguy.jenkins
   version: 4.3.0
-- name: geerlingguy.nginx
-  version: 2.8.0
 - name: geerlingguy.php
   version: 3.7.0
 - name: geerlingguy.php-versions
@@ -74,6 +72,10 @@
   version: v1.0.0
 - name: newrelic.newrelic-infra
   version: 0.8.2
+- name: nginxinc.nginx
+  version: 0.21.0
+- name: nginxinc.nginx_config
+  version: 0.3.3
 - name: nickhammond.logrotate
   version: v0.0.5
 - name: nleutner.newrelic-php

--- a/ansible/roles/software/common/php-fixes/molecule/default/Dockerfile.j2
+++ b/ansible/roles/software/common/php-fixes/molecule/default/Dockerfile.j2
@@ -6,9 +6,38 @@ FROM {{ item.registry.url }}/{{ item.image }}
 FROM {{ item.image }}
 {% endif %}
 
-RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates && apt-get clean; \
-    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python2-dnf bash && dnf clean all; \
-    elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
-    elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml && zypper clean -a; \
-    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \
-    elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python sudo bash ca-certificates && xbps-remove -O; fi
+{% if item.env is defined %}
+{% for var, value in item.env.items() %}
+{% if value %}
+ENV {{ var }} {{ value }}
+{% endif %}
+{% endfor %}
+{% endif %}
+
+RUN \
+  if [ $(command -v apt-get) ]; then \
+    apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y aptitude bash ca-certificates curl iproute2 python-apt python3 python3-apt procps sudo systemd systemd-sysv vim \
+    && apt-get clean; \
+  elif [ $(command -v dnf) ]; then \
+    dnf makecache \
+    && dnf --assumeyes install bash iproute sudo /usr/bin/dnf-3 /usr/bin/python3 /usr/bin/python3-config vim \
+    && dnf clean all; \
+  elif [ $(command -v yum) ]; then \
+    yum makecache fast \
+    && yum install -y bash iproute sudo /usr/bin/python /usr/bin/python2-config vim yum-plugin-ovl \
+    && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf \
+    && yum clean all; \
+  elif [ $(command -v zypper) ]; then \
+    zypper refresh \
+    && zypper install -y bash iproute2 python3 sudo vim \
+    && zypper clean -a; \
+  elif [ $(command -v apk) ]; then \
+    apk update \
+    && apk add --no-cache bash ca-certificates curl openrc python3 sudo vim; \
+    echo 'rc_provide="loopback net"' >> /etc/rc.conf; \
+  elif [ $(command -v xbps-install) ]; then \
+    xbps-install -Syu \
+    && xbps-install -y bash ca-certificates iproute2 python3 sudo vim \
+    && xbps-remove -O; \
+  fi

--- a/ansible/roles/software/common/php-fixes/molecule/default/molecule.yml
+++ b/ansible/roles/software/common/php-fixes/molecule/default/molecule.yml
@@ -9,6 +9,8 @@ lint: |
 platforms:
   - name: php-fixes-bionic
     image: ubuntu:bionic
+    privileged: true
+    command: "/sbin/init"
 provisioner:
   name: ansible
   lint: |

--- a/ansible/roles/software/common/php-fixes/molecule/default/prepare.yml
+++ b/ansible/roles/software/common/php-fixes/molecule/default/prepare.yml
@@ -12,7 +12,7 @@
       when: ppa is changed
 
   roles:
-    - role: geerlingguy.nginx
+    - role: nginxinc.nginx
     - role: geerlingguy.php-versions
       vars:
         php_version: 7.3

--- a/ansible/roles/software/common/php-fixes/molecule/default/requirements.yml
+++ b/ansible/roles/software/common/php-fixes/molecule/default/requirements.yml
@@ -1,7 +1,7 @@
 ---
-- src: geerlingguy.nginx
-  version: 2.6.2
 - src: geerlingguy.php-versions
   version: 3.1.1
 - src: geerlingguy.php
   version: 3.7.0
+- src: nginxinc.nginx
+  version: 0.21.0


### PR DESCRIPTION
For #3287.
Use official `nginxinc.nginx` role so we always have latest nginx.

Need to manually remove some config item added by `geerlingguy.nginx` role on existing instances.