### PR TITLE
use nginxinc.nginx to get latest stable nginx

### DIFF
--- a/ansible/dashboard-web.yml
+++ b/ansible/dashboard-web.yml
@@ -6,16 +6,60 @@
     - { role: software/common/tls, tags: [provision, tls] }
     - { role: software/common/php-common, tags: [provision] }
     - { role: geerlingguy.git, tags: [provision] }
-    - role: nginxinc.nginx
-      tags:
-        - nginx
-        - provision
     - { role: geerlingguy.php-versions, tags: [php, provision] }
     - { role: geerlingguy.php, tags: [php, provision] }
     - { role: geerlingguy.php-mysql, tags: [php, php-mysql, provision] }
     - { role: geerlingguy.php-memcached, tags: [php, php-memcached, provision] }
     - { role: software/common/php-fixes, tags: [php, provision] }
     - { role: geerlingguy.composer, tags: [php, provision] }
+
+
+- name: Deploy nginx
+  hosts: dashboard-web
+  roles:
+    - role: nginxinc.nginx
+      vars:
+        nginx_branch: stable
+        nginx_state: latest
+      tags: [nginx, provision]
+
+- name: Config nginx
+  hosts: dashboard-web
+  roles:
+    - role: nginxinc.nginx_config
+      vars:
+        nginx_config_cleanup_files:
+          - /etc/nginx/conf.d/default.conf
+
+        nginx_config_main_template_enable: true
+        nginx_config_main_template:
+          template_file: nginx.conf.j2
+          conf_file_name: nginx.conf
+          conf_file_location: /etc/nginx/
+          worker_processes: auto
+          pid: /var/run/nginx.pid
+          error_log:
+            location: /var/log/nginx/error.log
+            level: notice
+          worker_connections: 1024
+          http_enable: true
+          http_settings:
+            default_type: application/octet-stream
+            include: /etc/nginx/mime.types
+            access_log_format:
+              - name: main
+                format: |-
+                  '$remote_addr - $remote_user [$time_local] "$request" '
+                                      '$status $body_bytes_sent "$http_referer" '
+                                      '"$http_user_agent" "$http_x_forwarded_for"'
+            access_log_location:
+              - name: main
+                location: /var/log/nginx/access.log
+            sendfile: on
+            keepalive_timeout: 65
+            server_tokens: "off"
+      tags: [nginx, provision]
+
 
 
 - name: Deploying Dashboard

--- a/ansible/dashboard-web.yml
+++ b/ansible/dashboard-web.yml
@@ -6,7 +6,7 @@
     - { role: software/common/tls, tags: [provision, tls] }
     - { role: software/common/php-common, tags: [provision] }
     - { role: geerlingguy.git, tags: [provision] }
-    - role: geerlingguy.nginx
+    - role: nginxinc.nginx
       tags:
         - nginx
         - provision

--- a/ansible/dashboard-web.yml
+++ b/ansible/dashboard-web.yml
@@ -60,8 +60,6 @@
             server_tokens: "off"
       tags: [nginx, provision]
 
-
-
 - name: Deploying Dashboard
   hosts: dashboard-web
   serial: "{{ datagov_serial | default(1) }}"

--- a/ansible/datagov-web.yml
+++ b/ansible/datagov-web.yml
@@ -6,16 +6,58 @@
     - { role: software/common/tls, tags: [provision, tls] }
     - { role: software/common/php-common, tags: [provision] }
     - { role: geerlingguy.git, tags: [git, provision] }
-    - role: nginxinc.nginx
-      tags:
-        - nginx
-        - provision
     - { role: geerlingguy.php-versions, tags: [php, provision] }
     - { role: geerlingguy.php, tags: [php, provision] }
     - { role: geerlingguy.php-mysql, tags: [php, php-mysql, provision] }
     - { role: geerlingguy.php-memcached, tags: [php, php-memcached, provision] }
     - { role: software/common/php-fixes, tags: [php, provision] }
     - { role: geerlingguy.composer, tags: [php, provision] }
+
+- name: Deploy nginx
+  hosts: wordpress-web
+  roles:
+    - role: nginxinc.nginx
+      vars:
+        nginx_branch: stable
+        nginx_state: latest
+      tags: [nginx, provision]
+
+- name: Config nginx
+  hosts: wordpress-web
+  roles:
+    - role: nginxinc.nginx_config
+      vars:
+        nginx_config_cleanup_files:
+          - /etc/nginx/conf.d/default.conf
+
+        nginx_config_main_template_enable: true
+        nginx_config_main_template:
+          template_file: nginx.conf.j2
+          conf_file_name: nginx.conf
+          conf_file_location: /etc/nginx/
+          worker_processes: auto
+          pid: /var/run/nginx.pid
+          error_log:
+            location: /var/log/nginx/error.log
+            level: notice
+          worker_connections: 1024
+          http_enable: true
+          http_settings:
+            default_type: application/octet-stream
+            include: /etc/nginx/mime.types
+            access_log_format:
+              - name: main
+                format: |-
+                  '$remote_addr - $remote_user [$time_local] "$request" '
+                                      '$status $body_bytes_sent "$http_referer" '
+                                      '"$http_user_agent" "$http_x_forwarded_for"'
+            access_log_location:
+              - name: main
+                location: /var/log/nginx/access.log
+            sendfile: on
+            keepalive_timeout: 65
+            server_tokens: "off"
+      tags: [nginx, provision]
 
 - name: Deploying Data.gov
   hosts: wordpress-web

--- a/ansible/datagov-web.yml
+++ b/ansible/datagov-web.yml
@@ -6,7 +6,7 @@
     - { role: software/common/tls, tags: [provision, tls] }
     - { role: software/common/php-common, tags: [provision] }
     - { role: geerlingguy.git, tags: [git, provision] }
-    - role: geerlingguy.nginx
+    - role: nginxinc.nginx
       tags:
         - nginx
         - provision

--- a/ansible/fgdc2iso.yml
+++ b/ansible/fgdc2iso.yml
@@ -17,6 +17,9 @@
   hosts: catalog-fgdc2iso
   roles:
     - role: nginxinc.nginx
+      vars:
+        nginx_branch: stable
+        nginx_state: latest
       tags: [nginx, provision]
 
 - name: Config nginx

--- a/ansible/fgdc2iso.yml
+++ b/ansible/fgdc2iso.yml
@@ -16,31 +16,58 @@
 - name: Deploy nginx
   hosts: catalog-fgdc2iso
   roles:
-    - role: geerlingguy.nginx
+    - role: nginxinc.nginx
+      tags: [nginx, provision]
+
+- name: Config nginx
+  hosts: catalog-fgdc2iso
+  roles:
+    - role: nginxinc.nginx_config
       vars:
-        nginx_upstreams:
-          - name: "tomcat"
+        nginx_config_http_template_enable: true
+        nginx_config_http_template:
+          app:
+            template_file: http/default.conf.j2
+            conf_file_name: fgdc2iso.conf
+            conf_file_location: /etc/nginx/conf.d/
+            upstreams:
+              tomcat_upstream:
+                name: tomcat
+                servers:
+                  tomcat_server:
+                    address: 127.0.0.1
+                    port: 8080
             servers:
-              - "127.0.0.1:8080"
-        nginx_vhosts:
-          - listen: "80"
-            server_name: "fgdc2iso"
-            filename: "fgdc2iso.80.conf"
-            extra_parameters: |
-              location / {
-                proxy_pass http://tomcat;
-              }
-          - listen: "443 ssl"
-            server_name: "fgdc2iso"
-            filename: "fgdc2iso.443.conf"
-            extra_parameters: |
-              location / {
-                proxy_pass http://tomcat;
-              }
-              ssl_certificate     {{ fgdc2iso_tls_certificate_filepath | default(default_tls_host_certificate_filepath) }};
-              ssl_certificate_key {{ fgdc2iso_tls_key_filepath | default(default_tls_host_key_filepath) }};
-              ssl_protocols       TLSv1.2 TLSv1.3;
-              ssl_ciphers         HIGH:!aNULL:!MD5;
+              http_server:
+                listen:
+                  listen_localhost:
+                    ip: 0.0.0.0
+                    port: 80
+                server_name: fgdc2iso
+                reverse_proxy:
+                  locations:
+                    location1:
+                      location: /
+                      proxy_pass: http://tomcat
+
+              https_server:
+                listen:
+                  listen_localhost:
+                    ip: 0.0.0.0
+                    port: 443
+                    ssl: true
+                server_name: fgdc2iso
+                reverse_proxy:
+                  locations:
+                    location1:
+                      location: /
+                      proxy_pass: http://tomcat
+                ssl:
+                  cert: "{{ fgdc2iso_tls_certificate_filepath | default(default_tls_host_certificate_filepath) }}"
+                  key: "{{ fgdc2iso_tls_key_filepath | default(default_tls_host_key_filepath) }}"
+                  ciphers: "HIGH:!aNULL:!MD5"
+                  protocols: "TLSv1.2 TLSv1.3"
+
       tags: [nginx, provision]
 
 - name: Deploy fgdc2iso

--- a/ansible/jenkins.yml
+++ b/ansible/jenkins.yml
@@ -1,4 +1,51 @@
 ---
+- name: Deploy nginx
+  hosts: jenkins
+  roles:
+    - role: nginxinc.nginx
+      vars:
+        nginx_branch: stable
+        nginx_state: latest
+      tags: [nginx, provision]
+
+- name: Config nginx
+  hosts: jenkins
+  roles:
+    - role: nginxinc.nginx_config
+      vars:
+        nginx_config_cleanup_files:
+          - /etc/nginx/conf.d/default.conf
+
+        nginx_config_main_template_enable: true
+        nginx_config_main_template:
+          template_file: nginx.conf.j2
+          conf_file_name: nginx.conf
+          conf_file_location: /etc/nginx/
+          worker_processes: auto
+          pid: /var/run/nginx.pid
+          error_log:
+            location: /var/log/nginx/error.log
+            level: notice
+          worker_connections: 1024
+          http_enable: true
+          http_settings:
+            default_type: application/octet-stream
+            include: /etc/nginx/mime.types
+            access_log_format:
+              - name: main
+                format: |-
+                  '$remote_addr - $remote_user [$time_local] "$request" '
+                                      '$status $body_bytes_sent "$http_referer" '
+                                      '"$http_user_agent" "$http_x_forwarded_for"'
+            access_log_location:
+              - name: main
+                location: /var/log/nginx/access.log
+            sendfile: on
+            keepalive_timeout: 65
+            server_tokens: "off"
+      tags: [nginx, provision]
+
+
 - name: Install jenkins
   hosts: jenkins
   roles:

--- a/ansible/jenkins.yml
+++ b/ansible/jenkins.yml
@@ -49,9 +49,6 @@
 - name: Install jenkins
   hosts: jenkins
   roles:
-    - role: nginxinc.nginx
-      tags:
-        - nginx
     - role: gsa.datagov-deploy-jenkins
       tags:
         - jenkins

--- a/ansible/jenkins.yml
+++ b/ansible/jenkins.yml
@@ -2,7 +2,7 @@
 - name: Install jenkins
   hosts: jenkins
   roles:
-    - role: geerlingguy.nginx
+    - role: nginxinc.nginx
       tags:
         - nginx
     - role: gsa.datagov-deploy-jenkins

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -41,7 +41,7 @@
   version: 1.0.4
 - name: gsa.datagov-deploy-dashboard
   src: https://github.com/GSA/datagov-deploy-dashboard
-  version: v1.1.9
+  version: v1.2.0
 - name: gsa.datagov-deploy-apache2
   src: https://github.com/GSA/datagov-deploy-apache2
   version: v1.3.2
@@ -53,7 +53,7 @@
   version: v1.0.4
 - name: gsa.datagov-deploy-jenkins
   src: https://github.com/GSA/datagov-deploy-jenkins
-  version: v2.0.0
+  version: v2.1.0
 - name: gsa.datagov-deploy-jumpbox
   src: https://github.com/GSA/datagov-deploy-jumpbox
   version: v2.3.0
@@ -65,7 +65,7 @@
   version: v1.2.1
 - name: gsa.datagov-deploy-wordpress
   src: https://github.com/GSA/datagov-deploy-wordpress.git
-  version: v1.0.12
+  version: v1.1.0
 - name: jnv.unattended-upgrades
   version: v1.8.0
 - name: jobscore.beats

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -21,8 +21,6 @@
   version: 1.9.6
 - name: geerlingguy.jenkins
   version: 4.3.0
-- name: geerlingguy.nginx
-  version: 2.8.0
 - name: geerlingguy.php
   version: 3.7.0
 - name: geerlingguy.php-versions
@@ -74,6 +72,10 @@
   version: v1.0.0
 - name: newrelic.newrelic-infra
   version: 0.8.2
+- name: nginxinc.nginx
+  version: 0.21.0
+- name: nginxinc.nginx_config
+  version: 0.3.3
 - name: nickhammond.logrotate
   version: v0.0.5
 - name: nleutner.newrelic-php

--- a/ansible/roles/software/common/php-fixes/molecule/default/Dockerfile.j2
+++ b/ansible/roles/software/common/php-fixes/molecule/default/Dockerfile.j2
@@ -6,9 +6,38 @@ FROM {{ item.registry.url }}/{{ item.image }}
 FROM {{ item.image }}
 {% endif %}
 
-RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates && apt-get clean; \
-    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python2-dnf bash && dnf clean all; \
-    elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
-    elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml && zypper clean -a; \
-    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \
-    elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python sudo bash ca-certificates && xbps-remove -O; fi
+{% if item.env is defined %}
+{% for var, value in item.env.items() %}
+{% if value %}
+ENV {{ var }} {{ value }}
+{% endif %}
+{% endfor %}
+{% endif %}
+
+RUN \
+  if [ $(command -v apt-get) ]; then \
+    apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y aptitude bash ca-certificates curl iproute2 python-apt python3 python3-apt procps sudo systemd systemd-sysv vim \
+    && apt-get clean; \
+  elif [ $(command -v dnf) ]; then \
+    dnf makecache \
+    && dnf --assumeyes install bash iproute sudo /usr/bin/dnf-3 /usr/bin/python3 /usr/bin/python3-config vim \
+    && dnf clean all; \
+  elif [ $(command -v yum) ]; then \
+    yum makecache fast \
+    && yum install -y bash iproute sudo /usr/bin/python /usr/bin/python2-config vim yum-plugin-ovl \
+    && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf \
+    && yum clean all; \
+  elif [ $(command -v zypper) ]; then \
+    zypper refresh \
+    && zypper install -y bash iproute2 python3 sudo vim \
+    && zypper clean -a; \
+  elif [ $(command -v apk) ]; then \
+    apk update \
+    && apk add --no-cache bash ca-certificates curl openrc python3 sudo vim; \
+    echo 'rc_provide="loopback net"' >> /etc/rc.conf; \
+  elif [ $(command -v xbps-install) ]; then \
+    xbps-install -Syu \
+    && xbps-install -y bash ca-certificates iproute2 python3 sudo vim \
+    && xbps-remove -O; \
+  fi

--- a/ansible/roles/software/common/php-fixes/molecule/default/molecule.yml
+++ b/ansible/roles/software/common/php-fixes/molecule/default/molecule.yml
@@ -9,6 +9,8 @@ lint: |
 platforms:
   - name: php-fixes-bionic
     image: ubuntu:bionic
+    privileged: true
+    command: "/sbin/init"
 provisioner:
   name: ansible
   lint: |

--- a/ansible/roles/software/common/php-fixes/molecule/default/prepare.yml
+++ b/ansible/roles/software/common/php-fixes/molecule/default/prepare.yml
@@ -12,7 +12,7 @@
       when: ppa is changed
 
   roles:
-    - role: geerlingguy.nginx
+    - role: nginxinc.nginx
     - role: geerlingguy.php-versions
       vars:
         php_version: 7.3

--- a/ansible/roles/software/common/php-fixes/molecule/default/requirements.yml
+++ b/ansible/roles/software/common/php-fixes/molecule/default/requirements.yml
@@ -1,7 +1,7 @@
 ---
-- src: geerlingguy.nginx
-  version: 2.6.2
 - src: geerlingguy.php-versions
   version: 3.1.1
 - src: geerlingguy.php
   version: 3.7.0
+- src: nginxinc.nginx
+  version: 0.21.0


### PR DESCRIPTION
For #3287.
Use official nginxinc.nginx role so we have latest stable nginx.

Depends on new tags created from the following PRs
https://github.com/GSA/datagov-deploy-jenkins/pull/33
https://github.com/GSA/datagov-deploy-dashboard/pull/30
https://github.com/GSA/datagov-deploy-wordpress/pull/26

**PRE-DEPLOYMENT task**:
Need to manually remove some packages installed by ubuntu `nginx-extras` before deployment, on `fgdc2iso, jenkins, wordpress, dashboard` hosts.
```
# sudo apt purge nginx nginx-common nginx-extras
# sudo apt autoremove
# sudo rm -rf /etc/nginx

# sudo rm /etc/apt/sources.list.d/*nginx*
# sudo apt update
```

