### PR TITLE
set CORS header right so tracking can work

### DIFF
--- a/ansible/roles/software/ckan/catalog/ckan-app/templates/etc_apache2_sites-enabled_ckan.conf.j2
+++ b/ansible/roles/software/ckan/catalog/ckan-app/templates/etc_apache2_sites-enabled_ckan.conf.j2
@@ -55,9 +55,9 @@
     Header set X-XSS-Protection "1; mode=block"
     Header set X-Content-Type-Options "nosniff"
 
-    Header set Access-Control-Allow-Origin "*"
+    Header set Access-Control-Allow-Origin "https://catalog.data.gov"
     Header set Access-Control-Allow-Methods "POST, PUT, GET, DELETE, OPTIONS"
-    Header set Access-Control-Allow-Headers "X-CKAN-API-KEY, Authorization, Content-Type"
+    Header set Access-Control-Allow-Headers "X-CKAN-API-KEY, Authorization, Content-Type, x-requested-with"
 
     Header set Referrer-Policy "origin"
 


### PR DESCRIPTION
For https://github.com/GSA/datagov-deploy/issues/1478

1. Add `x-requested-with` to `Access-Control-Allow-Headers` so it matches with the OPTIONS requests from read-only site.
2. Limit Access-Control-Allow-Origin to read-only site domain instead of allowing all.