### PR TITLE
Add nginx default upload max size

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -7,52 +7,52 @@ ignore:
         reason: >-
           solaris_zone module is not used, fix requires ansible 2.9
           https://github.com/gsa/datagov-deploy/issues/893
-        expires: 2021-09-30T00:00:00.000Z
+        expires: 2021-10-14T00:00:00.000Z
 
   SNYK-PYTHON-ANSIBLE-1297166:
     - '*':
         reason: >-
           Ansible 3.0 upgrade work has a July2021 milestone
           https://github.com/GSA/datagov-deploy/issues/893
-        expires: 2021-09-30T00:00:00.000Z
+        expires: 2021-10-14T00:00:00.000Z
 
   SNYK-PYTHON-ANSIBLE-1292152:
     - '*':
         reason: >-
           Managed nodes are only accessible to data.gov operators. Risk is
           acceptable.
-        expires: 2021-09-30T06:00:00.000Z
+        expires: 2021-10-14T06:00:00.000Z
 
   SNYK-PYTHON-ANSIBLE-1292154:
     - '*':
         reason: >-
           Managed nodes are only accessible to data.gov operators. Risk is
           acceptable.
-        expires: 2021-09-30T06:00:00.000Z
+        expires: 2021-10-14T06:00:00.000Z
 
   SNYK-PYTHON-ANSIBLE-1300676:
     - '*':
         reason: >-
           Managed nodes are only accessible to data.gov operators. Risk is
           acceptable.
-        expires: 2021-09-30T06:00:00.000Z
+        expires: 2021-10-14T06:00:00.000Z
 
   SNYK-PYTHON-CRYPTOGRAPHY-1022152:
     - '*':
         reason: >-
           There is no fixed version for cryptography at this time (patch is applied, however)
           Only used in trusted environments, so risk is low.
-        expires: 2021-09-30T06:00:00.000Z
+        expires: 2021-10-14T06:00:00.000Z
 
   SNYK-PYTHON-ANSIBLE-1583870:
     - '*':
         reason: >-
           aws_ssm connection plugin is not used. No fixed version for ansible yet.
-        expires: 2021-09-30T06:00:00.000Z
+        expires: 2021-10-14T06:00:00.000Z
 
   SNYK-PYTHON-ANSIBLE-1583871:
     - '*':
         reason: >-
           aws_ssm connection plugin is not used. No fixed version for ansible yet.
-        expires: 2021-09-30T06:00:00.000Z
+        expires: 2021-10-14T06:00:00.000Z
 patch: {}

--- a/ansible/fgdc2iso.yml
+++ b/ansible/fgdc2iso.yml
@@ -42,6 +42,7 @@
                     port: 8080
             servers:
               http_server:
+                client_max_body_size: "{{ client_max_body_size | default('1m') }}"
                 listen:
                   listen_localhost:
                     ip: 0.0.0.0

--- a/ansible/group_vars/all/vars.yml
+++ b/ansible/group_vars/all/vars.yml
@@ -130,12 +130,8 @@ monit_apache2_mem_threshold: 82
 
 
 # Nginx
-nginx_remove_default_vhost: true
-nginx_ppa_use: true
-nginx_ppa_version: stable
-nginx_extra_conf_options: |-
-  include /etc/nginx/modules-enabled/*.conf;
-nginx_server_tokens: "off"
+# Transition to latest nginx changed default from 64 to 1, set default of 64 for all
+client_max_body_size: 64m
 
 
 # PHP

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -41,7 +41,7 @@
   version: 1.0.4
 - name: gsa.datagov-deploy-dashboard
   src: https://github.com/GSA/datagov-deploy-dashboard
-  version: v1.2.0
+  version: v1.2.1
 - name: gsa.datagov-deploy-apache2
   src: https://github.com/GSA/datagov-deploy-apache2
   version: v1.3.2
@@ -65,7 +65,7 @@
   version: v1.2.1
 - name: gsa.datagov-deploy-wordpress
   src: https://github.com/GSA/datagov-deploy-wordpress.git
-  version: v1.1.0
+  version: v1.1.1
 - name: jnv.unattended-upgrades
   version: v1.8.0
 - name: jobscore.beats


### PR DESCRIPTION
Transition to https://github.com/nginxinc/ansible-role-nginx caused change in default `max_body_size` from 64m to 1m. Getting requests from users to bump this back up.

Removes unused defaults from previous nginx deployment.

Did not see `client_max_body_size` support in `nginx_config_main_template` config, only in `nginx_config_http_template` config. `fgdc2iso` app is configured using `nginx_config_http_template` , therefore the edit is done in ansible file. `dashboard` and `wordpress` are configured using a conf file template, so the edits are done in their repos, we add them in by updating the requirement tag.

pending on new tags after https://github.com/GSA/datagov-deploy-dashboard/pull/32 and https://github.com/GSA/datagov-deploy-wordpress/pull/27 
